### PR TITLE
Unit test

### DIFF
--- a/tests/unit/cli/test_cli_options.cpp
+++ b/tests/unit/cli/test_cli_options.cpp
@@ -1,37 +1,58 @@
 // SPDX-License-Identifier: BSD-2-Clause
+//
+// Pins down: CLI option normalisation and argument parsing.
+//
+//   - normalize_options() supplies a 0.0.0.0/0 fallback prefix when
+//     none was given.
+//   - The XDP map-pin paths are derived from the chosen interface name
+//     (so two interfaces don't clobber each other's pinned maps).
+//   - `--queue auto` is accepted as a stand-in for an explicit queue id,
+//     and `--queue-probe-ms` flows through to the parsed options.
+//
+// If this fails: pre-flight defaults or pin-path derivation drift,
+// which surfaces as confusing "ENOENT for /sys/fs/bpf/openpenny_..."
+// errors at runtime.
 
 #include "openpenny/app/cli/cli_helpers.h"
 
 #include <cassert>
+#include <iostream>
 #include <string>
 
 int main() {
-    // Defaults: no prefix provided should normalize to 0.0.0.0/0.
-    openpenny::cli::CliOptions defaults;
-    auto normalized_default = openpenny::cli::normalize_options(defaults);
-    assert(normalized_default.prefix_cidr == "0.0.0.0/0");
-    assert(normalized_default.mask_bits == 0);
-    assert(normalized_default.mask_host == 0);
+    {
+        std::cout << "scenario: default options yield 0.0.0.0/0\n";
+        openpenny::cli::CliOptions defaults;
+        const auto out = openpenny::cli::normalize_options(defaults);
+        assert(out.prefix_cidr == "0.0.0.0/0");
+        assert(out.mask_bits   == 0);
+        assert(out.mask_host   == 0);
+    }
 
-    // Interface-specific pins are independent from traffic matching rules.
-    openpenny::cli::CliOptions with_iface;
-    with_iface.iface = "eth0";
-    auto normalized_with_iface = openpenny::cli::normalize_options(with_iface);
-    assert(normalized_with_iface.pin_conf_path.find("openpenny_eth0") != std::string::npos);
-    assert(!normalized_with_iface.pin_conf_path.empty());
-    assert(normalized_with_iface.pin_settings_path.find("openpenny_eth0") != std::string::npos);
+    {
+        std::cout << "scenario: --iface eth0 derives the pin paths\n";
+        openpenny::cli::CliOptions with_iface;
+        with_iface.iface = "eth0";
+        const auto out = openpenny::cli::normalize_options(with_iface);
+        assert(out.pin_conf_path.find("openpenny_eth0")     != std::string::npos);
+        assert(!out.pin_conf_path.empty());
+        assert(out.pin_settings_path.find("openpenny_eth0") != std::string::npos);
+    }
 
-    // Queue auto-probe should be accepted as an alternative to an explicit queue id.
-    const char* argv[] = {
-        "openpenny_cli",
-        "--queue", "auto",
-        "--queue-probe-ms", "750",
-    };
-    auto parsed = openpenny::cli::parse_args(static_cast<int>(sizeof(argv) / sizeof(argv[0])),
-                                             const_cast<char**>(argv));
-    assert(parsed.queue_auto);
-    assert(!parsed.queue_override);
-    assert(parsed.queue_probe_ms == 750);
+    {
+        std::cout << "scenario: --queue auto --queue-probe-ms 750 parses correctly\n";
+        const char* argv[] = {
+            "openpenny_cli",
+            "--queue", "auto",
+            "--queue-probe-ms", "750",
+        };
+        const auto parsed = openpenny::cli::parse_args(
+            static_cast<int>(sizeof(argv) / sizeof(argv[0])),
+            const_cast<char**>(argv));
+        assert(parsed.queue_auto);
+        assert(!parsed.queue_override);
+        assert(parsed.queue_probe_ms == 750);
+    }
 
     return 0;
 }

--- a/tests/unit/control/test_control_planner.cpp
+++ b/tests/unit/control/test_control_planner.cpp
@@ -1,89 +1,151 @@
 // SPDX-License-Identifier: BSD-2-Clause
+//
+// Pins down: the control-plane planner translates desired policy
+// objects into the compiled artifacts the dataplane consumes.
+//
+// Four scenarios:
+//   1. compile_traffic_policy() sorts rules by priority (lower first)
+//      and translates Include/Exclude to RedirectToUserspace/Pass.
+//   2. A full five-tuple rule survives compilation with every field
+//      preserved.
+//   3. compile_effective_config() produces an EffectiveConfig whose
+//      runtime mode and dataplane fields mirror the inputs. Warnings
+//      are non-empty because the example here pairs passive mode with
+//      AfXdp redirect, which the planner flags.
+//   4. desired_from_legacy_config() round-trips the legacy fields
+//      (cfg.input.backend, cfg.ifname, cfg.queue, cfg.passive.enabled,
+//      cfg.traffic_match) into the modern DesiredConfig.
+//
+// If this fails: policy edits via gRPC or YAML do not reach the
+// dataplane in the expected shape.
 
 #include "openpenny/control/Planner.h"
 
 #include <cassert>
+#include <iostream>
 
 int main() {
-    openpenny::control::TrafficPolicy policy{};
-    policy.default_decision = openpenny::control::TrafficDecision::Exclude;
+    using namespace openpenny::control;
+    using openpenny::net::TrafficIpPrefix;
+    using openpenny::net::TrafficRuleAction;
 
-    openpenny::control::TrafficPolicyRule include_rule{};
-    include_rule.name = "https";
-    include_rule.priority = 20;
-    include_rule.dst_port = 443;
-    include_rule.decision = openpenny::control::TrafficDecision::Include;
+    {
+        std::cout << "scenario: rules sort by priority; Include/Exclude map to redirect/pass\n";
+        TrafficPolicy policy{};
+        policy.default_decision = TrafficDecision::Exclude;
 
-    openpenny::control::TrafficPolicyRule exclude_rule{};
-    exclude_rule.name = "ssh";
-    exclude_rule.priority = 10;
-    exclude_rule.dst_port = 22;
-    exclude_rule.decision = openpenny::control::TrafficDecision::Exclude;
+        TrafficPolicyRule include_rule{};
+        include_rule.name     = "https";
+        include_rule.priority = 20;
+        include_rule.dst_port = 443;
+        include_rule.decision = TrafficDecision::Include;
 
-    policy.rules.push_back(include_rule);
-    policy.rules.push_back(exclude_rule);
+        TrafficPolicyRule exclude_rule{};
+        exclude_rule.name     = "ssh";
+        exclude_rule.priority = 10;
+        exclude_rule.dst_port = 22;
+        exclude_rule.decision = TrafficDecision::Exclude;
 
-    auto compiled = openpenny::control::compile_traffic_policy(policy);
-    assert(compiled.rules.size() == 2);
-    assert(compiled.rules[0].label == "ssh");
-    assert(compiled.rules[0].action == openpenny::net::TrafficRuleAction::Pass);
-    assert(compiled.rules[1].label == "https");
-    assert(compiled.rules[1].action == openpenny::net::TrafficRuleAction::RedirectToUserspace);
-    assert(compiled.default_action == openpenny::net::TrafficRuleAction::Pass);
+        policy.rules.push_back(include_rule);
+        policy.rules.push_back(exclude_rule);
 
-    openpenny::control::TrafficPolicy five_tuple_policy{};
-    openpenny::control::TrafficPolicyRule five_tuple_rule{};
-    five_tuple_rule.name = "five-tuple";
-    five_tuple_rule.src_ip = openpenny::net::TrafficIpPrefix{0x0a000000u, 0xff000000u};
-    five_tuple_rule.dst_ip = openpenny::net::TrafficIpPrefix{0xcb007100u, 0xffffff00u};
-    five_tuple_rule.ip_proto = 6;
-    five_tuple_rule.src_port = 12345;
-    five_tuple_rule.dst_port = 443;
-    five_tuple_policy.rules.push_back(five_tuple_rule);
+        const auto compiled = compile_traffic_policy(policy);
+        assert(compiled.rules.size()    == 2);
+        assert(compiled.rules[0].label  == "ssh");                          // priority 10 sorts first
+        assert(compiled.rules[0].action == TrafficRuleAction::Pass);
+        assert(compiled.rules[1].label  == "https");
+        assert(compiled.rules[1].action == TrafficRuleAction::RedirectToUserspace);
+        assert(compiled.default_action  == TrafficRuleAction::Pass);
+    }
 
-    auto five_tuple_compiled = openpenny::control::compile_traffic_policy(five_tuple_policy);
-    assert(five_tuple_compiled.rules.size() == 1);
-    assert(five_tuple_compiled.rules[0].src_ip.has_value());
-    assert(five_tuple_compiled.rules[0].dst_ip.has_value());
-    assert(five_tuple_compiled.rules[0].ip_proto == 6);
-    assert(five_tuple_compiled.rules[0].src_port == 12345);
-    assert(five_tuple_compiled.rules[0].dst_port == 443);
+    {
+        std::cout << "scenario: a full five-tuple rule round-trips through compile\n";
+        TrafficPolicy policy{};
+        TrafficPolicyRule rule{};
+        rule.name     = "five-tuple";
+        rule.src_ip   = TrafficIpPrefix{0x0a000000u, 0xff000000u};
+        rule.dst_ip   = TrafficIpPrefix{0xcb007100u, 0xffffff00u};
+        rule.ip_proto = 6;
+        rule.src_port = 12345;
+        rule.dst_port = 443;
+        policy.rules.push_back(rule);
 
-    openpenny::control::DesiredConfig desired{};
-    desired.traffic = policy;
-    desired.runtime.mode = openpenny::control::RuntimeMode::Passive;
-    desired.runtime.safety.allow_ssh_bypass = false;
-    desired.platform.backend = openpenny::control::PlatformBackend::AfXdp;
-    desired.platform.interface_name = "eth0";
-    desired.platform.queue = 0;
-    desired.platform.queue_count = 2;
-    desired.platform.worker_cpus = {4, 5};
+        const auto compiled = compile_traffic_policy(policy);
+        assert(compiled.rules.size() == 1);
+        assert(compiled.rules[0].src_ip.has_value());
+        assert(compiled.rules[0].dst_ip.has_value());
+        assert(compiled.rules[0].ip_proto == 6);
+        assert(compiled.rules[0].src_port == 12345);
+        assert(compiled.rules[0].dst_port == 443);
+    }
 
-    auto effective = openpenny::control::compile_effective_config(desired);
-    assert(effective.runtime.mode == openpenny::control::RuntimeMode::Passive);
-    assert(effective.dataplane.interface_name == "eth0");
-    assert(effective.dataplane.queue_count == 2);
-    assert(!effective.warnings.empty());
+    {
+        std::cout << "scenario: compile_effective_config mirrors desired into runtime + dataplane\n";
 
-    openpenny::Config legacy{};
-    legacy.input.backend = openpenny::PacketInputBackend::Dpdk;
-    legacy.ifname = "0000:01:00.0";
-    legacy.queue = 3;
-    legacy.queue_count = 1;
-    legacy.worker_cpus = {7};
-    legacy.mode = "passive";
-    legacy.passive.enabled = true;
-    legacy.active.enabled = false;
-    legacy.traffic_match = compiled;
+        // Build a small desired config and ensure the compiled effective
+        // config reflects mode/interface/queues correctly. The mismatch
+        // between passive mode and the AfXdp backend should emit a
+        // warning rather than silently picking one.
+        TrafficPolicy policy{};
+        TrafficPolicyRule rule{};
+        rule.name     = "https";
+        rule.dst_port = 443;
+        rule.decision = TrafficDecision::Include;
+        policy.rules.push_back(rule);
 
-    auto desired_from_legacy = openpenny::control::desired_from_legacy_config(legacy);
-    assert(desired_from_legacy.platform.backend == openpenny::control::PlatformBackend::Dpdk);
-    assert(desired_from_legacy.platform.interface_name == "0000:01:00.0");
-    assert(desired_from_legacy.platform.queue == 3);
-    assert(desired_from_legacy.platform.worker_cpus.size() == 1);
-    assert(desired_from_legacy.platform.worker_cpus[0] == 7);
-    assert(desired_from_legacy.runtime.mode == openpenny::control::RuntimeMode::Passive);
-    assert(desired_from_legacy.traffic.rules.size() == 2);
+        DesiredConfig desired{};
+        desired.traffic                       = policy;
+        desired.runtime.mode                  = RuntimeMode::Passive;
+        desired.runtime.safety.allow_ssh_bypass = false;
+        desired.platform.backend              = PlatformBackend::AfXdp;
+        desired.platform.interface_name       = "eth0";
+        desired.platform.queue                = 0;
+        desired.platform.queue_count          = 2;
+        desired.platform.worker_cpus          = {4, 5};
+
+        const auto effective = compile_effective_config(desired);
+        assert(effective.runtime.mode               == RuntimeMode::Passive);
+        assert(effective.dataplane.interface_name   == "eth0");
+        assert(effective.dataplane.queue_count      == 2);
+        assert(!effective.warnings.empty());
+    }
+
+    {
+        std::cout << "scenario: desired_from_legacy_config translates the legacy fields\n";
+        openpenny::Config legacy{};
+        legacy.input.backend   = openpenny::PacketInputBackend::Dpdk;
+        legacy.ifname          = "0000:01:00.0";
+        legacy.queue           = 3;
+        legacy.queue_count     = 1;
+        legacy.worker_cpus     = {7};
+        legacy.mode            = "passive";
+        legacy.passive.enabled = true;
+        legacy.active.enabled  = false;
+
+        // Plus the two compiled traffic rules from the first scenario.
+        TrafficPolicy seed{};
+        seed.default_decision = TrafficDecision::Exclude;
+        TrafficPolicyRule https{};
+        https.priority = 20;
+        https.dst_port = 443;
+        https.decision = TrafficDecision::Include;
+        TrafficPolicyRule ssh{};
+        ssh.priority = 10;
+        ssh.dst_port = 22;
+        ssh.decision = TrafficDecision::Exclude;
+        seed.rules.push_back(https);
+        seed.rules.push_back(ssh);
+        legacy.traffic_match = compile_traffic_policy(seed);
+
+        const auto desired = desired_from_legacy_config(legacy);
+        assert(desired.platform.backend         == PlatformBackend::Dpdk);
+        assert(desired.platform.interface_name  == "0000:01:00.0");
+        assert(desired.platform.queue           == 3);
+        assert(desired.platform.worker_cpus.size() == 1);
+        assert(desired.platform.worker_cpus[0]  == 7);
+        assert(desired.runtime.mode             == RuntimeMode::Passive);
+        assert(desired.traffic.rules.size()     == 2);
+    }
 
     return 0;
 }

--- a/tests/unit/control/test_control_planner.cpp
+++ b/tests/unit/control/test_control_planner.cpp
@@ -82,16 +82,28 @@ int main() {
     {
         std::cout << "scenario: compile_effective_config mirrors desired into runtime + dataplane\n";
 
-        // Build a small desired config and ensure the compiled effective
-        // config reflects mode/interface/queues correctly. The mismatch
-        // between passive mode and the AfXdp backend should emit a
-        // warning rather than silently picking one.
+        // Re-use the two-rule https/ssh shape from scenario 1 so the
+        // compile_effective_config() output matches what the planner
+        // sees from a typical policy. The combination here (passive +
+        // AfXdp + queue_count=2 with two worker_cpus) is expected to
+        // produce non-empty warnings.
         TrafficPolicy policy{};
-        TrafficPolicyRule rule{};
-        rule.name     = "https";
-        rule.dst_port = 443;
-        rule.decision = TrafficDecision::Include;
-        policy.rules.push_back(rule);
+        policy.default_decision = TrafficDecision::Exclude;
+
+        TrafficPolicyRule https{};
+        https.name     = "https";
+        https.priority = 20;
+        https.dst_port = 443;
+        https.decision = TrafficDecision::Include;
+
+        TrafficPolicyRule ssh{};
+        ssh.name     = "ssh";
+        ssh.priority = 10;
+        ssh.dst_port = 22;
+        ssh.decision = TrafficDecision::Exclude;
+
+        policy.rules.push_back(https);
+        policy.rules.push_back(ssh);
 
         DesiredConfig desired{};
         desired.traffic                       = policy;

--- a/tests/unit/flow/test_aggregate_drop_budget.cpp
+++ b/tests/unit/flow/test_aggregate_drop_budget.cpp
@@ -1,38 +1,55 @@
 // SPDX-License-Identifier: BSD-2-Clause
+//
+// Pins down: the cross-thread aggregate drop budget reservation
+// (`try_reserve_aggregate_drop`) is global across worker threads:
+//   - reservations from different per-thread shards each count toward
+//     the same shared total;
+//   - once the budget is consumed, further reservations are rejected;
+//   - re-initialising the per-thread counters resets the budget so a
+//     fresh pipeline run does not inherit drops from a previous one.
+//
+// If this fails: aggregate drop-cap enforcement double-counts or
+// leaks state across runs.
+
+#include "test_helpers.h"
 
 #include "openpenny/app/core/PerThreadStats.h"
 
 #include <cassert>
-#include <cstdint>
 
 int main() {
     using namespace openpenny::app;
+    using openpenny::test::Section;
 
-    init_thread_counters(3);
-    assert(aggregate_drop_budget_drops() == 0);
+    {
+        Section _{"three shards share one budget of 2"};
+        init_thread_counters(3);
+        assert(aggregate_drop_budget_drops() == 0);
 
-    set_thread_counter_index(0);
-    assert(try_reserve_aggregate_drop(2));
-    assert(aggregate_drop_budget_drops() == 1);
+        set_thread_counter_index(0);
+        assert(try_reserve_aggregate_drop(2));
+        assert(aggregate_drop_budget_drops() == 1);
 
-    set_thread_counter_index(1);
-    assert(try_reserve_aggregate_drop(2));
-    assert(aggregate_drop_budget_drops() == 2);
+        set_thread_counter_index(1);
+        assert(try_reserve_aggregate_drop(2));
+        assert(aggregate_drop_budget_drops() == 2);
 
-    set_thread_counter_index(2);
-    assert(!try_reserve_aggregate_drop(2));
-    assert(aggregate_drop_budget_drops() == 2);
+        set_thread_counter_index(2);
+        assert(!try_reserve_aggregate_drop(2)); // budget exhausted
+        assert(aggregate_drop_budget_drops() == 2);
+    }
 
-    // Initialisation should reset the dedicated aggregate-drop budget so a
-    // fresh pipeline run does not inherit drops from the previous one.
-    init_thread_counters(2);
-    set_thread_counter_index(0);
-    assert(aggregate_drop_budget_drops() == 0);
-    assert(try_reserve_aggregate_drop(1));
+    {
+        Section _{"init_thread_counters() resets the budget for a fresh run"};
+        init_thread_counters(2);
+        set_thread_counter_index(0);
+        assert(aggregate_drop_budget_drops() == 0);
+        assert(try_reserve_aggregate_drop(1));
 
-    set_thread_counter_index(1);
-    assert(!try_reserve_aggregate_drop(1));
-    assert(aggregate_drop_budget_drops() == 1);
+        set_thread_counter_index(1);
+        assert(!try_reserve_aggregate_drop(1)); // budget = 1 already consumed
+        assert(aggregate_drop_budget_drops() == 1);
+    }
 
     return 0;
 }

--- a/tests/unit/flow/test_aggregate_duplicate_fallback.cpp
+++ b/tests/unit/flow/test_aggregate_duplicate_fallback.cpp
@@ -1,4 +1,22 @@
 // SPDX-License-Identifier: BSD-2-Clause
+//
+// Pins down: the AggregatesController emits a DUPLICATES_EXCEEDED
+// verdict when the aggregate drop budget is consumed by a snapshot
+// whose stats already trip the per-flow duplicate threshold.
+//
+// Setup:
+//   - cfg.active.max_drops_aggregates = 1       (one snapshot fills the budget)
+//   - cfg.active.max_duplicate_fraction = 0.1   (per-flow dup threshold = 10%)
+//   - snapshot reports 10 data packets, 2 duplicates (= 20% > threshold)
+//
+// Expected: the controller flips runtime.aggregates_status from
+// PENDING to DUPLICATES_EXCEEDED, records the aggregate eval counters,
+// deactivates the aggregate, and closes the collector.
+//
+// If this fails: aggregate-level duplicate fallback never fires, so a
+// run that should stop early on duplicate-heavy traffic keeps going.
+
+#include "test_helpers.h"
 
 #include "openpenny/app/core/AggregatesController.h"
 #include "openpenny/app/core/DropCollectorBinding.h"
@@ -9,7 +27,6 @@
 #include <atomic>
 #include <cassert>
 #include <chrono>
-#include <cstdint>
 #include <functional>
 #include <memory>
 #include <thread>
@@ -17,95 +34,103 @@
 namespace {
 
 openpenny::FlowKey make_key() {
-    openpenny::FlowKey key{};
-    key.src = 0x0a000011;
-    key.dst = 0x0a000012;
-    key.sport = 2222;
-    key.dport = 5201;
-    key.ip_proto = 6;
-    return key;
+    openpenny::FlowKey k{};
+    k.src      = 0x0a000011;
+    k.dst      = 0x0a000012;
+    k.sport    = 2222;
+    k.dport    = 5201;
+    k.ip_proto = 6;
+    return k;
 }
 
+// A snapshot that already trips the per-flow duplicate threshold
+// (10 data, 2 duplicates, 1 drop, 1 non-retransmit).
 openpenny::penny::PacketDropSnapshot make_duplicate_exceeded_snapshot() {
-    openpenny::penny::PacketDropSnapshot snap{};
-    snap.timestamp = std::chrono::steady_clock::now();
-    snap.state = openpenny::penny::SnapshotState::Expired;
+    openpenny::penny::PacketDropSnapshot s{};
+    s.timestamp = std::chrono::steady_clock::now();
+    s.state     = openpenny::penny::SnapshotState::Expired;
     for (int i = 0; i < 10; ++i) {
-        snap.stats.record_data_packet();
-        snap.stats.record_droppable_packet();
+        s.stats.record_data_packet();
+        s.stats.record_droppable_packet();
     }
-    for (int i = 0; i < 2; ++i) {
-        snap.stats.record_duplicate_packet();
-    }
-    snap.stats.record_drop();
-    snap.stats.inc_non_retransmitted();
-    return snap;
+    for (int i = 0; i < 2; ++i) s.stats.record_duplicate_packet();
+    s.stats.record_drop();
+    s.stats.inc_non_retransmitted();
+    return s;
 }
 
 } // namespace
 
 int main() {
+    using openpenny::test::Section;
+    using AggStatus = openpenny::RuntimeStatus::AggregatesStatus;
+
     openpenny::app::init_thread_counters(1);
     openpenny::app::set_thread_counter_index(0);
 
     openpenny::Config cfg;
-    cfg.active.aggregates_enabled = true;
-    cfg.active.max_drops_aggregates = 1;
-    cfg.active.max_duplicate_fraction = 0.1;
+    cfg.active.aggregates_enabled              = true;
+    cfg.active.max_drops_aggregates            = 1;
+    cfg.active.max_duplicate_fraction          = 0.1;
     cfg.active.retransmission_miss_probability = 0.0;
-    cfg.active.min_closed_loop_flows = 0;
+    cfg.active.min_closed_loop_flows           = 0;
 
     openpenny::PipelineOptions opts{};
     opts.mode = openpenny::PipelineOptions::Mode::Active;
-
     openpenny::set_runtime_setup(cfg, opts, false, false);
+
     auto& runtime = openpenny::runtime_setup_mutable();
-    runtime.aggregates_status = openpenny::RuntimeStatus::AggregatesStatus::PENDING;
-    runtime.aggregate_eval_counters = {};
-    runtime.has_aggregate_eval = false;
-    runtime.aggregates_active = true;
+    runtime.aggregates_status        = AggStatus::PENDING;
+    runtime.aggregate_eval_counters  = {};
+    runtime.has_aggregate_eval       = false;
+    runtime.aggregates_active        = true;
 
     std::atomic<bool> stop_flag{false};
     auto collector = std::make_shared<openpenny::DropCollector>(1);
     openpenny::AggregatesController controller(
-        cfg,
-        opts,
-        collector,
-        stop_flag,
-        std::function<bool()>{});
-    controller.start();
+        cfg, opts, collector, stop_flag, std::function<bool()>{});
 
-    auto& counters = openpenny::app::current_thread_counters();
-    counters.droppable_packets = 10;
-    counters.data_packets = 10;
-    counters.duplicate_packets = 2;
-    counters.dropped_packets = 1;
-    counters.non_retransmitted_packets = 1;
-    counters.pending_retransmissions = 0;
+    {
+        Section _{"controller runs; per-thread counters reflect duplicate-heavy flow"};
+        controller.start();
 
-    openpenny::app::DropCollectorBinding::instance().upsert(
-        collector,
-        "worker-0",
-        0,
-        make_key(),
-        openpenny::penny::make_packet_drop_id(2000, 100),
-        make_duplicate_exceeded_snapshot());
-
-    const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(1);
-    while (runtime.aggregates_status == openpenny::RuntimeStatus::AggregatesStatus::PENDING &&
-           std::chrono::steady_clock::now() < deadline) {
-        std::this_thread::sleep_for(std::chrono::milliseconds(10));
+        auto& counters = openpenny::app::current_thread_counters();
+        counters.droppable_packets         = 10;
+        counters.data_packets              = 10;
+        counters.duplicate_packets         = 2;
+        counters.dropped_packets           = 1;
+        counters.non_retransmitted_packets = 1;
+        counters.pending_retransmissions   = 0;
     }
 
-    assert(runtime.aggregates_status ==
-           openpenny::RuntimeStatus::AggregatesStatus::DUPLICATES_EXCEEDED);
-    assert(runtime.has_aggregate_eval);
-    assert(runtime.aggregate_eval_counters.data_packets == 10);
-    assert(runtime.aggregate_eval_counters.duplicate_packets == 2);
-    assert(!runtime.aggregates_active);
-    assert(!collector->accepting.load(std::memory_order_relaxed));
-    assert(!controller.collector_completed());
-    assert(!stop_flag.load(std::memory_order_relaxed));
+    {
+        Section _{"single drop snapshot consumes the aggregate budget"};
+        openpenny::app::DropCollectorBinding::instance().upsert(
+            collector,
+            "worker-0",
+            0,
+            make_key(),
+            openpenny::penny::make_packet_drop_id(2000, 100),
+            make_duplicate_exceeded_snapshot());
+
+        const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(1);
+        while (runtime.aggregates_status == AggStatus::PENDING &&
+               std::chrono::steady_clock::now() < deadline) {
+            std::this_thread::sleep_for(std::chrono::milliseconds(10));
+        }
+    }
+
+    {
+        Section _{"verdict is DUPLICATES_EXCEEDED; aggregate eval populated; collector closed"};
+        assert(runtime.aggregates_status == AggStatus::DUPLICATES_EXCEEDED);
+        assert(runtime.has_aggregate_eval);
+        assert(runtime.aggregate_eval_counters.data_packets      == 10);
+        assert(runtime.aggregate_eval_counters.duplicate_packets == 2);
+        assert(!runtime.aggregates_active);
+        assert(!collector->accepting.load(std::memory_order_relaxed));
+        assert(!controller.collector_completed());
+        assert(!stop_flag.load(std::memory_order_relaxed));
+    }
 
     stop_flag.store(true, std::memory_order_relaxed);
     controller.join();

--- a/tests/unit/flow/test_aggregate_freeze_at_drop_limit.cpp
+++ b/tests/unit/flow/test_aggregate_freeze_at_drop_limit.cpp
@@ -1,4 +1,30 @@
 // SPDX-License-Identifier: BSD-2-Clause
+//
+// Pins down: when the aggregate drop budget is exhausted, the
+// DropCollector freezes — further drop-snapshot upserts are rejected,
+// existing snapshots can still transition (e.g. expire), and on
+// teardown the controller emits NON_CLOSED_LOOP for the snapshot that
+// reached terminal state without retransmissions.
+//
+// Setup:
+//   - max_drops_aggregates = 1   (only the first upsert is accepted)
+//   - max_duplicate_fraction = 1 (duplicate fallback off)
+//   - retransmission_miss_probability = 0
+//
+// Steps:
+//   1. Upsert snapshot A (pending). Budget consumed; accepted=1.
+//   2. Upsert snapshot B (pending). Budget full; rejected. accepted stays 1.
+//   3. Mutate A to Expired (the late retransmit deadline path) and
+//      upsert again — same record, allowed; transitions through.
+//   4. populate_drop_snapshots() returns exactly the one frozen record.
+//   5. evaluate_pending_if_needed() lifts the verdict to NON_CLOSED_LOOP
+//      with aggregate eval counters reflecting snapshot A's stats.
+//
+// If this fails: the aggregate budget either accepts too many records
+// (overshoots `max_drops_aggregates`) or refuses legitimate transitions
+// of already-accepted snapshots.
+
+#include "test_helpers.h"
 
 #include "openpenny/app/core/AggregatesController.h"
 #include "openpenny/app/core/DropCollectorBinding.h"
@@ -9,125 +35,122 @@
 #include <atomic>
 #include <cassert>
 #include <chrono>
-#include <cstdint>
 #include <functional>
 #include <memory>
 
 namespace {
 
 openpenny::FlowKey make_key(std::uint16_t sport) {
-    openpenny::FlowKey key{};
-    key.src = 0x0a000001;
-    key.dst = 0x0a000002;
-    key.sport = sport;
-    key.dport = 5201;
-    key.ip_proto = 6;
-    return key;
+    openpenny::FlowKey k{};
+    k.src      = 0x0a000001;
+    k.dst      = 0x0a000002;
+    k.sport    = sport;
+    k.dport    = 5201;
+    k.ip_proto = 6;
+    return k;
 }
 
 openpenny::penny::PacketDropSnapshot make_pending_snapshot() {
-    openpenny::penny::PacketDropSnapshot snap{};
-    snap.timestamp = std::chrono::steady_clock::now();
-    snap.state = openpenny::penny::SnapshotState::Pending;
-    snap.stats.record_data_packet();
-    snap.stats.record_droppable_packet();
-    snap.stats.record_drop();
-    snap.stats.inc_pending_retransmission();
-    return snap;
+    openpenny::penny::PacketDropSnapshot s{};
+    s.timestamp = std::chrono::steady_clock::now();
+    s.state     = openpenny::penny::SnapshotState::Pending;
+    s.stats.record_data_packet();
+    s.stats.record_droppable_packet();
+    s.stats.record_drop();
+    s.stats.inc_pending_retransmission();
+    return s;
 }
 
 } // namespace
 
 int main() {
+    using openpenny::test::Section;
+    using AggStatus = openpenny::RuntimeStatus::AggregatesStatus;
+
     openpenny::app::init_thread_counters(1);
     openpenny::app::set_thread_counter_index(0);
 
     openpenny::Config cfg;
-    cfg.active.aggregates_enabled = true;
-    cfg.active.max_drops_aggregates = 1;
-    cfg.active.max_duplicate_fraction = 1.0;
+    cfg.active.aggregates_enabled              = true;
+    cfg.active.max_drops_aggregates            = 1;
+    cfg.active.max_duplicate_fraction          = 1.0;
     cfg.active.retransmission_miss_probability = 0.0;
 
     openpenny::PipelineOptions opts{};
     opts.mode = openpenny::PipelineOptions::Mode::Active;
-
     openpenny::set_runtime_setup(cfg, opts, false, false);
+
     auto& runtime = openpenny::runtime_setup_mutable();
-    runtime.aggregates_status = openpenny::RuntimeStatus::AggregatesStatus::PENDING;
-    runtime.aggregate_eval_counters = {};
-    runtime.has_aggregate_eval = false;
-    runtime.aggregates_active = true;
+    runtime.aggregates_status        = AggStatus::PENDING;
+    runtime.aggregate_eval_counters  = {};
+    runtime.has_aggregate_eval       = false;
+    runtime.aggregates_active        = true;
 
     std::atomic<bool> stop_flag{false};
     auto collector = std::make_shared<openpenny::DropCollector>(1);
     openpenny::AggregatesController controller(
-        cfg,
-        opts,
-        collector,
-        stop_flag,
-        std::function<bool()>{});
+        cfg, opts, collector, stop_flag, std::function<bool()>{});
 
     auto& counters = openpenny::app::current_thread_counters();
-    counters.droppable_packets = 10;
-    counters.data_packets = 10;
-    counters.dropped_packets = 1;
-    counters.pending_retransmissions = 1;
 
-    const auto first_key = make_key(40001);
-    const auto first_id = openpenny::penny::make_packet_drop_id(1000, 100);
-    auto first_snapshot = make_pending_snapshot();
-    openpenny::app::DropCollectorBinding::instance().upsert(
-        collector,
-        "worker-0",
-        0,
-        first_key,
-        first_id,
-        first_snapshot);
+    const auto first_key  = make_key(40001);
+    const auto first_id   = openpenny::penny::make_packet_drop_id(1000, 100);
+    auto       first_snap = make_pending_snapshot();
 
-    counters.droppable_packets = 100;
-    counters.data_packets = 100;
-    counters.dropped_packets = 2;
-    counters.pending_retransmissions = 2;
+    {
+        Section _{"snapshot A (pending) is accepted; budget = 1/1"};
+        counters.droppable_packets       = 10;
+        counters.data_packets            = 10;
+        counters.dropped_packets         = 1;
+        counters.pending_retransmissions = 1;
 
-    const auto second_key = make_key(40002);
-    const auto second_id = openpenny::penny::make_packet_drop_id(2000, 100);
-    auto second_snapshot = make_pending_snapshot();
-    openpenny::app::DropCollectorBinding::instance().upsert(
-        collector,
-        "worker-0",
-        0,
-        second_key,
-        second_id,
-        second_snapshot);
+        openpenny::app::DropCollectorBinding::instance().upsert(
+            collector, "worker-0", 0, first_key, first_id, first_snap);
+    }
 
-    assert(collector->accepted_snapshot_count.load(std::memory_order_relaxed) == 1);
+    {
+        Section _{"snapshot B (pending) is rejected; budget full"};
+        counters.droppable_packets       = 100;
+        counters.data_packets            = 100;
+        counters.dropped_packets         = 2;
+        counters.pending_retransmissions = 2;
 
-    counters.pending_retransmissions = 0;
-    counters.non_retransmitted_packets = 50;
-    first_snapshot.state = openpenny::penny::SnapshotState::Expired;
-    first_snapshot.stats.dec_pending_retransmission();
-    first_snapshot.stats.inc_non_retransmitted();
-    openpenny::app::DropCollectorBinding::instance().upsert(
-        collector,
-        "worker-0",
-        0,
-        first_key,
-        first_id,
-        first_snapshot);
+        const auto second_key  = make_key(40002);
+        const auto second_id   = openpenny::penny::make_packet_drop_id(2000, 100);
+        auto       second_snap = make_pending_snapshot();
 
-    openpenny::PipelineSummary summary;
-    controller.populate_drop_snapshots(summary);
-    assert(summary.drop_snapshots.size() == 1);
+        openpenny::app::DropCollectorBinding::instance().upsert(
+            collector, "worker-0", 0, second_key, second_id, second_snap);
+        assert(collector->accepted_snapshot_count.load(std::memory_order_relaxed) == 1);
+    }
 
-    controller.evaluate_pending_if_needed(cfg, summary);
+    {
+        Section _{"snapshot A transitions to Expired; existing record updates in place"};
+        counters.pending_retransmissions   = 0;
+        counters.non_retransmitted_packets = 50;
+        first_snap.state = openpenny::penny::SnapshotState::Expired;
+        first_snap.stats.dec_pending_retransmission();
+        first_snap.stats.inc_non_retransmitted();
 
-    assert(runtime.aggregates_status ==
-           openpenny::RuntimeStatus::AggregatesStatus::NON_CLOSED_LOOP);
-    assert(runtime.has_aggregate_eval);
-    assert(runtime.aggregate_eval_counters.data_packets == 10);
-    assert(runtime.aggregate_eval_counters.duplicate_packets == 0);
-    assert(runtime.aggregate_eval_counters.retransmitted_packets == 0);
-    assert(runtime.aggregate_eval_counters.non_retransmitted_packets == 1);
+        openpenny::app::DropCollectorBinding::instance().upsert(
+            collector, "worker-0", 0, first_key, first_id, first_snap);
+    }
+
+    {
+        Section _{"summary exposes exactly the one accepted record"};
+        openpenny::PipelineSummary summary;
+        controller.populate_drop_snapshots(summary);
+        assert(summary.drop_snapshots.size() == 1);
+
+        controller.evaluate_pending_if_needed(cfg, summary);
+
+        assert(runtime.aggregates_status == AggStatus::NON_CLOSED_LOOP);
+        assert(runtime.has_aggregate_eval);
+        assert(runtime.aggregate_eval_counters.data_packets             == 10);
+        assert(runtime.aggregate_eval_counters.duplicate_packets        == 0);
+        assert(runtime.aggregate_eval_counters.retransmitted_packets    == 0);
+        assert(runtime.aggregate_eval_counters.non_retransmitted_packets == 1);
+    }
 
     return 0;
 }

--- a/tests/unit/flow/test_aggregate_pending_resolution.cpp
+++ b/tests/unit/flow/test_aggregate_pending_resolution.cpp
@@ -1,4 +1,19 @@
 // SPDX-License-Identifier: BSD-2-Clause
+//
+// Pins down: AggregatesController::evaluate_pending_if_needed()
+// produces the correct verdict for three end-of-run snapshot states:
+//
+//   1. Expired snapshot      -> NON_CLOSED_LOOP (no retransmission seen).
+//   2. Invalid snapshot      -> NON_CLOSED_LOOP (the drop never produced
+//      enough evidence either way; verdict still falls negative).
+//   3. Expired + duplicate
+//      threshold exceeded     -> DUPLICATES_EXCEEDED (duplicate fallback
+//      wins over plain not-closed-loop).
+//
+// If this fails: end-of-run aggregate evaluation produces the wrong
+// final status, which is what the CLI / gRPC clients report.
+
+#include "test_helpers.h"
 
 #include "openpenny/app/core/AggregatesController.h"
 #include "openpenny/app/core/PerThreadStats.h"
@@ -8,137 +23,136 @@
 #include <atomic>
 #include <cassert>
 #include <chrono>
+#include <functional>
+#include <memory>
 
 namespace {
 
-openpenny::DropSnapshotRecord make_expired_snapshot_record() {
-    openpenny::DropSnapshotRecord record{};
-    record.key.src = 0x0a000001;
-    record.key.dst = 0x0a000002;
-    record.key.sport = 1111;
-    record.key.dport = 5201;
-    record.key.ip_proto = 6;
-    record.packet_id = openpenny::penny::make_packet_drop_id(1000, 100);
-    record.snapshot.timestamp = std::chrono::steady_clock::now();
-    record.snapshot.state = openpenny::penny::SnapshotState::Expired;
+openpenny::DropSnapshotRecord make_expired_record() {
+    openpenny::DropSnapshotRecord r{};
+    r.key.src      = 0x0a000001;
+    r.key.dst      = 0x0a000002;
+    r.key.sport    = 1111;
+    r.key.dport    = 5201;
+    r.key.ip_proto = 6;
+    r.packet_id    = openpenny::penny::make_packet_drop_id(1000, 100);
+    r.snapshot.timestamp = std::chrono::steady_clock::now();
+    r.snapshot.state     = openpenny::penny::SnapshotState::Expired;
     for (int i = 0; i < 5; ++i) {
-        record.snapshot.stats.record_data_packet();
-        record.snapshot.stats.record_droppable_packet();
+        r.snapshot.stats.record_data_packet();
+        r.snapshot.stats.record_droppable_packet();
     }
-    record.snapshot.stats.record_drop();
-    record.snapshot.stats.inc_non_retransmitted();
-    return record;
+    r.snapshot.stats.record_drop();
+    r.snapshot.stats.inc_non_retransmitted();
+    return r;
 }
 
-openpenny::DropSnapshotRecord make_invalid_snapshot_record() {
-    auto record = make_expired_snapshot_record();
-    record.snapshot.state = openpenny::penny::SnapshotState::Invalid;
-    record.snapshot.stats = {};
+openpenny::DropSnapshotRecord make_invalid_record() {
+    auto r = make_expired_record();
+    r.snapshot.state = openpenny::penny::SnapshotState::Invalid;
+    r.snapshot.stats = {};
     for (int i = 0; i < 5; ++i) {
-        record.snapshot.stats.record_data_packet();
-        record.snapshot.stats.record_droppable_packet();
+        r.snapshot.stats.record_data_packet();
+        r.snapshot.stats.record_droppable_packet();
     }
-    record.snapshot.stats.record_drop();
-    return record;
+    r.snapshot.stats.record_drop();
+    return r;
 }
 
-openpenny::DropSnapshotRecord make_duplicate_exceeded_snapshot_record() {
-    openpenny::DropSnapshotRecord record{};
-    record.key.src = 0x0a000011;
-    record.key.dst = 0x0a000012;
-    record.key.sport = 2222;
-    record.key.dport = 5201;
-    record.key.ip_proto = 6;
-    record.packet_id = openpenny::penny::make_packet_drop_id(2000, 100);
-    record.snapshot.timestamp = std::chrono::steady_clock::now();
-    record.snapshot.state = openpenny::penny::SnapshotState::Expired;
+openpenny::DropSnapshotRecord make_duplicate_exceeded_record() {
+    openpenny::DropSnapshotRecord r{};
+    r.key.src      = 0x0a000011;
+    r.key.dst      = 0x0a000012;
+    r.key.sport    = 2222;
+    r.key.dport    = 5201;
+    r.key.ip_proto = 6;
+    r.packet_id    = openpenny::penny::make_packet_drop_id(2000, 100);
+    r.snapshot.timestamp = std::chrono::steady_clock::now();
+    r.snapshot.state     = openpenny::penny::SnapshotState::Expired;
     for (int i = 0; i < 10; ++i) {
-        record.snapshot.stats.record_data_packet();
-        record.snapshot.stats.record_droppable_packet();
+        r.snapshot.stats.record_data_packet();
+        r.snapshot.stats.record_droppable_packet();
     }
-    for (int i = 0; i < 2; ++i) {
-        record.snapshot.stats.record_duplicate_packet();
-    }
-    record.snapshot.stats.record_drop();
-    record.snapshot.stats.inc_non_retransmitted();
-    return record;
+    for (int i = 0; i < 2; ++i) r.snapshot.stats.record_duplicate_packet();
+    r.snapshot.stats.record_drop();
+    r.snapshot.stats.inc_non_retransmitted();
+    return r;
+}
+
+// Reset runtime to a clean PENDING state before each scenario.
+void reset_runtime(openpenny::RuntimeStatus& runtime) {
+    openpenny::set_current_aggregates_status(
+        openpenny::RuntimeStatus::AggregatesStatus::PENDING);
+    runtime.aggregate_eval_counters = {};
+    openpenny::set_current_has_aggregate_eval(false);
+    openpenny::set_current_aggregates_active(true);
 }
 
 } // namespace
 
 int main() {
+    using openpenny::test::Section;
+    using AggStatus = openpenny::RuntimeStatus::AggregatesStatus;
+
     openpenny::app::init_thread_counters(1);
     openpenny::app::set_thread_counter_index(0);
 
     openpenny::Config cfg;
-    cfg.active.aggregates_enabled = true;
-    cfg.active.max_drops_aggregates = 1;
-    cfg.active.max_duplicate_fraction = 1.0;
+    cfg.active.aggregates_enabled              = true;
+    cfg.active.max_drops_aggregates            = 1;
+    cfg.active.max_duplicate_fraction          = 1.0;
     cfg.active.retransmission_miss_probability = 0.0;
 
     openpenny::PipelineOptions opts{};
     opts.mode = openpenny::PipelineOptions::Mode::Active;
-
     openpenny::set_runtime_setup(cfg, opts, false, false);
-    auto& runtime = openpenny::runtime_setup_mutable();
-    openpenny::set_current_aggregates_status(
-        openpenny::RuntimeStatus::AggregatesStatus::PENDING);
-    runtime.aggregate_eval_counters = {};
-    openpenny::set_current_has_aggregate_eval(false);
-    openpenny::set_current_aggregates_active(true);
 
+    auto& runtime = openpenny::runtime_setup_mutable();
     std::atomic<bool> stop_flag{false};
     auto collector = std::make_shared<openpenny::DropCollector>(1);
     openpenny::AggregatesController controller(
-        cfg,
-        opts,
-        collector,
-        stop_flag,
-        std::function<bool()>{});
+        cfg, opts, collector, stop_flag, std::function<bool()>{});
 
-    openpenny::PipelineSummary summary;
-    summary.drop_snapshots.push_back(make_expired_snapshot_record());
+    {
+        Section _{"Expired snapshot -> NON_CLOSED_LOOP"};
+        reset_runtime(runtime);
 
-    controller.evaluate_pending_if_needed(cfg, summary);
+        openpenny::PipelineSummary summary;
+        summary.drop_snapshots.push_back(make_expired_record());
+        controller.evaluate_pending_if_needed(cfg, summary);
 
-    assert(runtime.aggregates_status ==
-           openpenny::RuntimeStatus::AggregatesStatus::NON_CLOSED_LOOP);
-    assert(runtime.has_aggregate_eval);
-    assert(controller.aggregates_ready());
-    assert(controller.collector_completed());
+        assert(runtime.aggregates_status == AggStatus::NON_CLOSED_LOOP);
+        assert(runtime.has_aggregate_eval);
+        assert(controller.aggregates_ready());
+        assert(controller.collector_completed());
+    }
 
-    openpenny::set_current_aggregates_status(
-        openpenny::RuntimeStatus::AggregatesStatus::PENDING);
-    runtime.aggregate_eval_counters = {};
-    openpenny::set_current_has_aggregate_eval(false);
-    openpenny::set_current_aggregates_active(true);
+    {
+        Section _{"Invalid snapshot -> NON_CLOSED_LOOP"};
+        reset_runtime(runtime);
 
-    openpenny::PipelineSummary invalid_summary;
-    invalid_summary.drop_snapshots.push_back(make_invalid_snapshot_record());
+        openpenny::PipelineSummary summary;
+        summary.drop_snapshots.push_back(make_invalid_record());
+        controller.evaluate_pending_if_needed(cfg, summary);
 
-    controller.evaluate_pending_if_needed(cfg, invalid_summary);
+        assert(runtime.aggregates_status == AggStatus::NON_CLOSED_LOOP);
+        assert(runtime.has_aggregate_eval);
+    }
 
-    assert(runtime.aggregates_status ==
-           openpenny::RuntimeStatus::AggregatesStatus::NON_CLOSED_LOOP);
-    assert(runtime.has_aggregate_eval);
+    {
+        Section _{"Expired snapshot + duplicate-ratio threshold -> DUPLICATES_EXCEEDED"};
+        reset_runtime(runtime);
+        cfg.active.max_duplicate_fraction = 0.1; // tighten so 2/10 trips it
 
-    openpenny::set_current_aggregates_status(
-        openpenny::RuntimeStatus::AggregatesStatus::PENDING);
-    runtime.aggregate_eval_counters = {};
-    openpenny::set_current_has_aggregate_eval(false);
-    openpenny::set_current_aggregates_active(true);
-    cfg.active.max_duplicate_fraction = 0.1;
+        openpenny::PipelineSummary summary;
+        summary.drop_snapshots.push_back(make_duplicate_exceeded_record());
+        controller.evaluate_pending_if_needed(cfg, summary);
 
-    openpenny::PipelineSummary duplicate_summary;
-    duplicate_summary.drop_snapshots.push_back(make_duplicate_exceeded_snapshot_record());
-
-    controller.evaluate_pending_if_needed(cfg, duplicate_summary);
-
-    assert(runtime.aggregates_status ==
-           openpenny::RuntimeStatus::AggregatesStatus::DUPLICATES_EXCEEDED);
-    assert(runtime.has_aggregate_eval);
-    assert(runtime.aggregate_eval_counters.data_packets == 10);
-    assert(runtime.aggregate_eval_counters.duplicate_packets == 2);
+        assert(runtime.aggregates_status == AggStatus::DUPLICATES_EXCEEDED);
+        assert(runtime.has_aggregate_eval);
+        assert(runtime.aggregate_eval_counters.data_packets      == 10);
+        assert(runtime.aggregate_eval_counters.duplicate_packets == 2);
+    }
 
     return 0;
 }

--- a/tests/unit/flow/test_drop_snapshot_updates.cpp
+++ b/tests/unit/flow/test_drop_snapshot_updates.cpp
@@ -1,175 +1,149 @@
 // SPDX-License-Identifier: BSD-2-Clause
 //
-// Tests how `FlowEngine` snapshots evolve as drops, retransmissions and
-// duplicates are recorded. Each call to `drop_packet()` captures a
-// `PacketDropSnapshot` whose `.stats` field is a frozen copy of the
-// flow's stats at that instant. Later events MUST update both the
-// flow-wide counters AND the matching snapshot, *and propagate forward*
-// to every newer snapshot — older snapshots stay untouched.
+// Pins down: drop snapshots evolve correctly as drops, retransmissions
+// and duplicates are recorded.
 //
-// Coverage:
-//   1. Two consecutive drops correctly bump the flow's pending count and
-//      append a snapshot per drop, with each snapshot's frozen stats
-//      reflecting the count at that moment.
-//   2. `register_filled_gaps()` (a successful retransmission of an
-//      earlier drop) decrements pending on the matching snapshot and on
-//      every later snapshot, but does not touch older snapshots.
-//   3. `register_duplicate_snapshot()` increments duplicate_packets only
-//      on snapshots whose covered seq range is *at or after* the
-//      duplicate's sequence number — i.e. duplicates seen "after" a
-//      snapshot affect that snapshot, but duplicates with smaller seq
-//      affect every snapshot up the chain.
+// Contract: each call to `drop_packet()` captures a `PacketDropSnapshot`
+// whose `.stats` field is a frozen copy of the flow's stats at that
+// instant. Later events MUST update the matching snapshot AND propagate
+// forward to every newer snapshot — older snapshots stay untouched.
 //
-// Synchronization caveat:
-//   `FlowEngine::register_filled_gaps()` enqueues a Retransmit event on
-//   the thread-local `ThreadFlowEventTimerManager`; the actual mutation
-//   is applied when the worker drains callbacks. The test polls and
-//   drives that drain explicitly so the assertions observe the updated
-//   snapshots deterministically.
+// Scenarios:
+//   1. Two consecutive drops bump pending and append a snapshot per
+//      drop, each with its own frozen stats.
+//   2. `register_filled_gaps()` (the success path) decrements pending
+//      on the matching snapshot and on every later snapshot; older
+//      snapshots are not touched.
+//   3. `register_duplicate_snapshot()` increments duplicate_packets on
+//      snapshots whose covered seq range is at or after the duplicate's
+//      seq. Duplicates with seq smaller than a snapshot's range update
+//      every snapshot up the chain.
+//
+// Synchronisation note: `register_filled_gaps()` enqueues a Retransmit
+// event on the thread-local `ThreadFlowEventTimerManager`; the
+// mutation runs when the worker drains callbacks. The test polls and
+// drives that drain explicitly so assertions are deterministic.
+
+#include "test_helpers.h"
 
 #include "openpenny/config/Config.h"
-#include "openpenny/penny/flow/engine/FlowEngine.h"
 #include "openpenny/net/Packet.h"
+#include "openpenny/penny/flow/engine/FlowEngine.h"
 
 #include <cassert>
 #include <chrono>
-#include <thread>
 #include <vector>
 
 using namespace std::chrono;
+using openpenny::test::Section;
+using TimerMgr = openpenny::penny::ThreadFlowEventTimerManager;
 
 namespace {
 
-// Wait up to `timeout` for `predicate()` to become true. Used to
-// synchronise the test thread with the cooperative timer manager.
+// Wait up to `timeout` for `predicate()`. Drains timer callbacks each
+// pass so the cooperative event path makes progress.
 template <class Predicate>
 bool wait_for(Predicate predicate, milliseconds timeout = milliseconds{2000}) {
     const auto deadline = steady_clock::now() + timeout;
     while (steady_clock::now() < deadline) {
-        openpenny::penny::ThreadFlowEventTimerManager::instance().drain_callbacks();
+        TimerMgr::instance().drain_callbacks();
         if (predicate()) return true;
         std::this_thread::sleep_for(milliseconds{5});
     }
-    openpenny::penny::ThreadFlowEventTimerManager::instance().drain_callbacks();
+    TimerMgr::instance().drain_callbacks();
     return predicate();
 }
 
 } // namespace
 
 int main() {
-    // ----------------------------------------------------------------
-    // Setup
-    // ----------------------------------------------------------------
     openpenny::Config cfg;
-    // drop_probability=1.0 makes drop_packet() always drop, so the test
-    // is deterministic regardless of the random number generator state.
-    cfg.active.drop_probability = 1.0;
-    // Long retransmission timeout. With `now = steady_clock::now()`, the
-    // deadline = `now + 60s` lies far in the future so the cooperative
-    // expiry path never runs during this test — only the explicit
-    // `register_filled_gaps()` events do. (The test's assertions break
-    // if `mark_snapshot_expired` also runs and decrements pending on
-    // entries we haven't filled yet.)
+    // Always drop, so the test is deterministic regardless of RNG state.
+    cfg.active.drop_probability   = 1.0;
+    // Generous deadline; only the explicit register_filled_gaps() path
+    // should produce snapshot transitions during this test.
     cfg.active.rtt_timeout_factor = 60.0;
 
     openpenny::penny::FlowEngine flow(cfg.active);
 
-    // Real wall-clock timestamp so timer deadlines land in the future.
     auto now = steady_clock::now();
     openpenny::FlowKey key{};
 
-    // ----------------------------------------------------------------
-    // Phase 1: two drops in increasing-seq order
-    // ----------------------------------------------------------------
-    // First drop: seq 1000-1100. record_data() advertises that the seq
-    // was observed (so drop_packet has a flow position to attach to).
     const auto drop1_id = openpenny::penny::make_packet_drop_id(1000, 100);
     const auto drop2_id = openpenny::penny::make_packet_drop_id(2000, 100);
-    flow.record_data(1000, now);
-    bool dropped1 = flow.drop_packet(1000, 1100, drop1_id, key, now);
-    assert(dropped1);
-    assert(flow.pending_retransmissions() == 1);
-    assert(flow.drop_snapshots().size() == 1);
 
-    // Second drop: seq 2000-2100. Pending count climbs to 2, and the
-    // snapshot vector grows to two entries.
-    flow.record_data(2000, now);
-    bool dropped2 = flow.drop_packet(2000, 2100, drop2_id, key, now);
-    assert(dropped2);
-    assert(flow.pending_retransmissions() == 2);
-    assert(flow.drop_snapshots().size() == 2);
+    {
+        Section _{"two drops appended in order; pending climbs 1 then 2"};
 
-    // ----------------------------------------------------------------
-    // Phase 1 verification: each snapshot's frozen stats
-    // ----------------------------------------------------------------
-    // Insertion order: FlowEngine appends each new drop with
-    // emplace_back, so the OLDEST drop sits at front() and the NEWEST
-    // at back().
-    const auto& snaps_before_fill = flow.drop_snapshots();
-    auto& snap_drop1_before = snaps_before_fill.front().second; // drop1, oldest
-    auto& snap_drop2_before = snaps_before_fill.back().second;  // drop2, newest
+        flow.record_data(1000, now);
+        assert(flow.drop_packet(1000, 1100, drop1_id, key, now));
+        assert(flow.pending_retransmissions() == 1);
+        assert(flow.drop_snapshots().size()   == 1);
 
-    // drop1's snapshot was taken right after the FIRST drop, so it sees
-    // pending=1 frozen in time. drop2's snapshot was taken after the
-    // SECOND drop, so it sees pending=2.
-    assert(snap_drop1_before.stats.pending_retransmissions() == 1);
-    assert(snap_drop2_before.stats.pending_retransmissions() == 2);
-    // No retransmissions yet — neither snapshot has been "filled".
-    assert(snap_drop1_before.stats.retransmitted_packets() == 0);
-    assert(snap_drop2_before.stats.retransmitted_packets() == 0);
+        flow.record_data(2000, now);
+        assert(flow.drop_packet(2000, 2100, drop2_id, key, now));
+        assert(flow.pending_retransmissions() == 2);
+        assert(flow.drop_snapshots().size()   == 2);
+    }
 
-    // ----------------------------------------------------------------
-    // Phase 2: drop1 is retransmitted (gap filled by a later packet)
-    // ----------------------------------------------------------------
-    // register_filled_gaps() queues a Retransmit event on the timer
-    // manager. drain_callbacks() then applies
-    // mark_snapshot_retransmitted on this thread's FlowEngine, which:
-    //   - decrements flow_stats_.pending_retransmissions by 1,
-    //   - increments flow_stats_.retransmitted_packets by 1,
-    //   - flips drop1's snapshot to Retransmitted state,
-    //   - propagates the change to drop2's snapshot (the only later one
-    //     still Pending), bumping its retransmitted_packets and
-    //     decrementing its frozen pending count.
-    flow.register_filled_gaps(std::vector<openpenny::penny::PacketDropId>{drop1_id});
+    {
+        Section _{"frozen stats: drop1 sees pending=1, drop2 sees pending=2"};
 
-    // Drain the queued retransmit event before asserting.
-    assert(wait_for([&] { return flow.retransmitted_packets() == 1; }));
+        const auto& snaps = flow.drop_snapshots();
+        const auto& s1 = snaps.front().second; // oldest
+        const auto& s2 = snaps.back().second;  // newest
+        assert(s1.stats.pending_retransmissions() == 1);
+        assert(s2.stats.pending_retransmissions() == 2);
+        assert(s1.stats.retransmitted_packets()   == 0);
+        assert(s2.stats.retransmitted_packets()   == 0);
+    }
 
-    // Phase 2 verification: flow-wide counters
-    assert(flow.pending_retransmissions() == 1);
-    assert(flow.retransmitted_packets() == 1);
+    {
+        Section _{"register_filled_gaps(drop1) -> drop1 Retransmitted, drop2 forward-updated"};
 
-    // Phase 2 verification: per-snapshot frozen stats
-    const auto& snaps_after_fill = flow.drop_snapshots();
-    auto& snap_drop1_after = snaps_after_fill.front().second; // drop1, oldest
-    auto& snap_drop2_after = snaps_after_fill.back().second;  // drop2, newest
-    // drop1 itself: pending dropped to 0, retransmitted bumped to 1.
-    assert(snap_drop1_after.stats.pending_retransmissions() == 0);
-    assert(snap_drop1_after.stats.retransmitted_packets() == 1);
-    // drop2 (later snapshot): forward propagation also drops its frozen
-    // pending count by 1 (2 -> 1) and bumps its retransmitted (0 -> 1).
-    assert(snap_drop2_after.stats.pending_retransmissions() == 1);
-    assert(snap_drop2_after.stats.retransmitted_packets() == 1);
+        flow.register_filled_gaps(std::vector<openpenny::penny::PacketDropId>{drop1_id});
+        assert(wait_for([&] { return flow.retransmitted_packets() == 1; }));
 
-    // ----------------------------------------------------------------
-    // Phase 3: duplicate observations and the seq-coverage rule
-    // ----------------------------------------------------------------
-    // Duplicate at seq 1950 — falls between drop1 (1000) and drop2
-    // (2000). Only snapshots whose covered range INCLUDES 1950 should
-    // be incremented. drop1's snapshot's coverage ends at 1100 < 1950,
-    // so drop1 is NOT touched. drop2's coverage extends past 1950
-    // (its highest seq seen at the time of the snapshot was 2000), so
-    // drop2 IS incremented.
-    flow.register_duplicate_snapshot(1950);
-    assert(snap_drop1_after.stats.duplicate_packets() == 0);
-    assert(snap_drop2_after.stats.duplicate_packets() == 1);
+        // Flow-wide counters.
+        assert(flow.pending_retransmissions() == 1);
+        assert(flow.retransmitted_packets()   == 1);
 
-    // Duplicate at seq 900 — earlier than drop1 itself. Both snapshots
-    // cover that seq (drop1: 1000 >= 900; drop2: 2000 >= 900), so both
-    // increment.
-    flow.register_duplicate_snapshot(900);
-    assert(snap_drop1_after.stats.duplicate_packets() == 1);
-    assert(snap_drop2_after.stats.duplicate_packets() == 2);
+        // Per-snapshot frozen stats.
+        const auto& snaps = flow.drop_snapshots();
+        const auto& s1 = snaps.front().second;
+        const auto& s2 = snaps.back().second;
+
+        // drop1 itself: pending 1 -> 0, retransmitted 0 -> 1.
+        assert(s1.stats.pending_retransmissions() == 0);
+        assert(s1.stats.retransmitted_packets()   == 1);
+
+        // drop2 (newer): forward propagation drops pending 2 -> 1 and
+        // bumps retransmitted 0 -> 1.
+        assert(s2.stats.pending_retransmissions() == 1);
+        assert(s2.stats.retransmitted_packets()   == 1);
+    }
+
+    {
+        Section _{"duplicate at seq 1950 only updates snapshots covering >= 1950"};
+
+        flow.register_duplicate_snapshot(1950);
+        const auto& s1 = flow.drop_snapshots().front().second;
+        const auto& s2 = flow.drop_snapshots().back().second;
+        // drop1 coverage ends at 1100 < 1950 -> untouched.
+        // drop2 coverage extends past 1950 -> incremented.
+        assert(s1.stats.duplicate_packets() == 0);
+        assert(s2.stats.duplicate_packets() == 1);
+    }
+
+    {
+        Section _{"duplicate at seq 900 (earlier than every drop) updates both"};
+
+        flow.register_duplicate_snapshot(900);
+        const auto& s1 = flow.drop_snapshots().front().second;
+        const auto& s2 = flow.drop_snapshots().back().second;
+        assert(s1.stats.duplicate_packets() == 1);
+        assert(s2.stats.duplicate_packets() == 2);
+    }
 
     return 0;
 }

--- a/tests/unit/flow/test_drop_timer.cpp
+++ b/tests/unit/flow/test_drop_timer.cpp
@@ -1,125 +1,131 @@
 // SPDX-License-Identifier: BSD-2-Clause
+//
+// Pins down: the ThreadFlowEventTimerManager arbitrates between drop
+// expiration and a retransmit event, and publishes the resulting
+// counter change into the right per-thread shard.
+//
+// Three scenarios:
+//   1. Expiration deadline reached before the retransmit event lands ->
+//      snapshot ends Expired, non_retransmitted incremented.
+//   2. Retransmit arrives well before the deadline -> snapshot ends
+//      Retransmitted, retransmitted_packets incremented.
+//   3. With multiple per-thread counter shards, the timer callback
+//      must publish into the shard owned by the worker that holds the
+//      flow — otherwise aggregate pending_retransmissions never drains.
+//
+// If this fails: flow verdicts hang on stuck pending_retransmissions
+// or are computed on the wrong worker thread's counters.
 
-#include "openpenny/config/Config.h"
-#include "openpenny/penny/flow/timer/ThreadFlowEventTimer.h"
-#include "openpenny/penny/flow/state/PennySnapshot.h"
-#include "openpenny/penny/flow/engine/FlowEngine.h"
+#include "test_helpers.h"
+
 #include "openpenny/app/core/PerThreadStats.h"
+#include "openpenny/config/Config.h"
 #include "openpenny/net/Packet.h"
+#include "openpenny/penny/flow/engine/FlowEngine.h"
+#include "openpenny/penny/flow/state/PennySnapshot.h"
+#include "openpenny/penny/flow/timer/ThreadFlowEventTimer.h"
 
 #include <cassert>
 #include <chrono>
-#include <thread>
 
-using namespace std::chrono_literals;
-
-static void sleep_for_ms(int ms) { std::this_thread::sleep_for(std::chrono::milliseconds(ms)); }
+using openpenny::test::Section;
+using openpenny::test::reset_drop_timer;
+using openpenny::test::sleep_ms;
+using TimerMgr = openpenny::penny::ThreadFlowEventTimerManager;
 
 int main() {
-    // Start from a clean timer state.
-    openpenny::penny::ThreadFlowEventTimerManager::instance().stop();
+    reset_drop_timer();
 
-    // Expiration should win when it is due at wakeup time (even if a retransmit arrives then).
     {
+        Section _{"expiration wins when retransmit arrives after the deadline"};
         openpenny::Config cfg;
-        cfg.active.drop_probability = 1.0; // always drop
-        cfg.active.rtt_timeout_factor = 0.05;       // 50ms deadline
+        cfg.active.drop_probability   = 1.0;   // always drop
+        cfg.active.rtt_timeout_factor = 0.05;  // 50ms deadline
 
         openpenny::penny::FlowEngine flow(cfg.active);
         openpenny::FlowKey key{};
-        const auto now = std::chrono::steady_clock::now();
+        const auto now       = std::chrono::steady_clock::now();
         const auto packet_id = openpenny::penny::make_packet_drop_id(1000, 100);
 
         flow.record_data(1000, now);
-        bool dropped = flow.drop_packet(1000, 1100, packet_id, key, now);
-        assert(dropped);
+        assert(flow.drop_packet(1000, 1100, packet_id, key, now));
         assert(flow.pending_retransmissions() == 1);
 
-        // Wait past the expiration deadline, then enqueue a retransmit event.
-        sleep_for_ms(80);
-        openpenny::penny::ThreadFlowEventTimerManager::instance().enqueue_retransmitted(packet_id, &flow);
-
-        sleep_for_ms(80);
-        openpenny::penny::ThreadFlowEventTimerManager::instance().drain_callbacks();
+        sleep_ms(80);                                          // past deadline
+        TimerMgr::instance().enqueue_retransmitted(packet_id, &flow);
+        sleep_ms(80);
+        TimerMgr::instance().drain_callbacks();
 
         const auto& snaps = flow.drop_snapshots();
         assert(snaps.size() == 1);
-        const auto& snap = snaps.front().second;
-        assert(snap.state == openpenny::penny::SnapshotState::Expired);
-        assert(flow.pending_retransmissions() == 0);
+        assert(snaps.front().second.state == openpenny::penny::SnapshotState::Expired);
+        assert(flow.pending_retransmissions()   == 0);
         assert(flow.non_retransmitted_packets() == 1);
-        assert(flow.retransmitted_packets() == 0);
+        assert(flow.retransmitted_packets()     == 0);
     }
 
-    // Reset timer to allow a new timeout value.
-    openpenny::penny::ThreadFlowEventTimerManager::instance().stop();
+    reset_drop_timer();
 
-    // Retransmit should be processed before expiration when the deadline is still in the future.
     {
+        Section _{"retransmit wins when it arrives well before the deadline"};
         openpenny::Config cfg;
-        cfg.active.drop_probability = 1.0; // always drop
-        cfg.active.rtt_timeout_factor = 0.5;        // 500ms deadline to leave headroom
+        cfg.active.drop_probability   = 1.0;
+        cfg.active.rtt_timeout_factor = 0.5;   // 500ms deadline, plenty of headroom
 
         openpenny::penny::FlowEngine flow(cfg.active);
         openpenny::FlowKey key{};
-        const auto now = std::chrono::steady_clock::now();
+        const auto now       = std::chrono::steady_clock::now();
         const auto packet_id = openpenny::penny::make_packet_drop_id(2000, 100);
 
         flow.record_data(2000, now);
-        bool dropped = flow.drop_packet(2000, 2100, packet_id, key, now);
-        assert(dropped);
+        assert(flow.drop_packet(2000, 2100, packet_id, key, now));
         assert(flow.pending_retransmissions() == 1);
 
-        // Enqueue retransmit well before deadline so event path runs first.
-        sleep_for_ms(20);
-        openpenny::penny::ThreadFlowEventTimerManager::instance().enqueue_retransmitted(packet_id, &flow);
-        sleep_for_ms(150);
-        openpenny::penny::ThreadFlowEventTimerManager::instance().drain_callbacks();
+        sleep_ms(20);                                          // well within deadline
+        TimerMgr::instance().enqueue_retransmitted(packet_id, &flow);
+        sleep_ms(150);
+        TimerMgr::instance().drain_callbacks();
 
         const auto& snaps = flow.drop_snapshots();
         assert(snaps.size() == 1);
-        const auto& snap = snaps.front().second;
-        assert(snap.state == openpenny::penny::SnapshotState::Retransmitted);
-        assert(flow.pending_retransmissions() == 0);
-        assert(flow.retransmitted_packets() == 1);
-        assert(flow.non_retransmitted_packets() == 0);
+        assert(snaps.front().second.state == openpenny::penny::SnapshotState::Retransmitted);
+        assert(flow.pending_retransmissions()    == 0);
+        assert(flow.retransmitted_packets()      == 1);
+        assert(flow.non_retransmitted_packets()  == 0);
     }
 
-    // Timer callbacks must publish into the same per-thread counter shard as the
-    // worker that owns the flow; otherwise multi-queue aggregate pending_rtx can
-    // stay stuck forever.
-    openpenny::penny::ThreadFlowEventTimerManager::instance().stop();
+    reset_drop_timer();
     openpenny::app::init_thread_counters(2);
     openpenny::app::set_thread_counter_index(1);
+
     {
+        Section _{"timer publishes into the owning worker's per-thread counter shard"};
         openpenny::Config cfg;
-        cfg.active.drop_probability = 1.0;
+        cfg.active.drop_probability   = 1.0;
         cfg.active.rtt_timeout_factor = 0.05;
 
         openpenny::penny::FlowEngine flow(cfg.active);
         openpenny::FlowKey key{};
-        const auto now = std::chrono::steady_clock::now();
+        const auto now       = std::chrono::steady_clock::now();
         const auto packet_id = openpenny::penny::make_packet_drop_id(3000, 100);
 
         flow.record_data(3000, now);
-        const bool dropped = flow.drop_packet(3000, 3100, packet_id, key, now);
-        assert(dropped);
+        assert(flow.drop_packet(3000, 3100, packet_id, key, now));
         assert(openpenny::app::aggregate_counters().pending_retransmissions == 1);
 
-        sleep_for_ms(80);
-        openpenny::penny::ThreadFlowEventTimerManager::instance().drain_callbacks();
+        sleep_ms(80);
+        TimerMgr::instance().drain_callbacks();
 
         const auto counters = openpenny::app::thread_counters();
         assert(counters.size() >= 2);
-        assert(counters[0].pending_retransmissions == 0);
-        assert(counters[0].non_retransmitted_packets == 0);
-        assert(counters[1].pending_retransmissions == 0);
-        assert(counters[1].non_retransmitted_packets == 1);
-        assert(openpenny::app::aggregate_counters().pending_retransmissions == 0);
-        assert(openpenny::app::aggregate_counters().non_retransmitted_packets == 1);
+        assert(counters[0].pending_retransmissions    == 0);
+        assert(counters[0].non_retransmitted_packets  == 0);
+        assert(counters[1].pending_retransmissions    == 0);
+        assert(counters[1].non_retransmitted_packets  == 1);
+        assert(openpenny::app::aggregate_counters().pending_retransmissions    == 0);
+        assert(openpenny::app::aggregate_counters().non_retransmitted_packets  == 1);
     }
 
-    // Clean shutdown for other tests.
-    openpenny::penny::ThreadFlowEventTimerManager::instance().stop();
+    reset_drop_timer();
     return 0;
 }

--- a/tests/unit/flow/test_flow_evaluation_phase_gate.cpp
+++ b/tests/unit/flow/test_flow_evaluation_phase_gate.cpp
@@ -1,4 +1,19 @@
 // SPDX-License-Identifier: BSD-2-Clause
+//
+// Pins down: per-flow evaluation is gated on the aggregate status when
+// `aggregates_enabled` is true. A flow's local duplicate threshold
+// alone must NOT promote it to a terminal decision while:
+//   - the aggregate is still PENDING, or
+//   - the aggregate has reached CLOSED_LOOP (a positive result that
+//     should not trigger per-flow duplicate-exceeded fallback).
+// Only when the aggregate emits NON_CLOSED_LOOP may a per-flow
+// duplicate-exceeded verdict fire, as the duplicate-fallback path.
+//
+// If this fails: per-flow heuristics race past the aggregate verdict,
+// breaking the contract that aggregate evaluation is authoritative for
+// closed-loop / non-closed-loop classification.
+
+#include "test_helpers.h"
 
 #include "openpenny/app/core/PerThreadStats.h"
 #include "openpenny/app/core/RuntimeSetup.h"
@@ -7,46 +22,60 @@
 
 #include <cassert>
 
+using openpenny::test::Section;
+using FlowDecision = openpenny::penny::FlowEngine::FlowDecision;
+using AggStatus    = openpenny::RuntimeStatus::AggregatesStatus;
+
+// Build a flow that has tripped its local duplicate threshold (50%).
+static openpenny::penny::FlowEngine make_dup_heavy_flow(const openpenny::Config& cfg) {
+    openpenny::penny::FlowEngine flow(cfg.active);
+    flow.record_data_packet();
+    flow.record_duplicate_packet();
+    return flow;
+}
+
 int main() {
     openpenny::app::init_thread_counters(1);
     openpenny::app::set_thread_counter_index(0);
 
     openpenny::Config cfg;
-    cfg.active.aggregates_enabled = true;
-    cfg.active.max_drops_aggregates = 1;
+    cfg.active.aggregates_enabled     = true;
+    cfg.active.max_drops_aggregates   = 1;
     cfg.active.max_duplicate_fraction = 0.5;
 
     openpenny::PipelineOptions opts{};
     opts.mode = openpenny::PipelineOptions::Mode::Active;
-
     openpenny::set_runtime_setup(cfg, opts, false, false);
-    openpenny::set_current_aggregates_status(
-        openpenny::RuntimeStatus::AggregatesStatus::PENDING);
-    openpenny::set_current_aggregates_active(true);
 
-    openpenny::penny::FlowEngine flow(cfg.active);
-    flow.record_data_packet();
-    flow.record_duplicate_packet();
+    {
+        Section _{"aggregate PENDING -> per-flow stays PENDING"};
+        openpenny::set_current_aggregates_status(AggStatus::PENDING);
+        openpenny::set_current_aggregates_active(true);
 
-    flow.evaluate_if_ready();
-    assert(flow.final_decision() ==
-           openpenny::penny::FlowEngine::FlowDecision::PENDING);
+        auto flow = make_dup_heavy_flow(cfg);
+        flow.evaluate_if_ready();
+        assert(flow.final_decision() == FlowDecision::PENDING);
+    }
 
-    openpenny::set_current_aggregates_status(
-        openpenny::RuntimeStatus::AggregatesStatus::CLOSED_LOOP);
-    openpenny::set_current_aggregates_active(false);
+    {
+        Section _{"aggregate CLOSED_LOOP -> per-flow stays PENDING (no fallback)"};
+        openpenny::set_current_aggregates_status(AggStatus::CLOSED_LOOP);
+        openpenny::set_current_aggregates_active(false);
 
-    flow.evaluate_if_ready();
-    assert(flow.final_decision() ==
-           openpenny::penny::FlowEngine::FlowDecision::PENDING);
+        auto flow = make_dup_heavy_flow(cfg);
+        flow.evaluate_if_ready();
+        assert(flow.final_decision() == FlowDecision::PENDING);
+    }
 
-    openpenny::set_current_aggregates_status(
-        openpenny::RuntimeStatus::AggregatesStatus::NON_CLOSED_LOOP);
-    openpenny::set_current_aggregates_active(false);
+    {
+        Section _{"aggregate NON_CLOSED_LOOP -> per-flow duplicate-exceeded fires"};
+        openpenny::set_current_aggregates_status(AggStatus::NON_CLOSED_LOOP);
+        openpenny::set_current_aggregates_active(false);
 
-    flow.evaluate_if_ready();
-    assert(flow.final_decision() ==
-           openpenny::penny::FlowEngine::FlowDecision::FINISHED_DUPLICATE_EXCEEDED);
+        auto flow = make_dup_heavy_flow(cfg);
+        flow.evaluate_if_ready();
+        assert(flow.final_decision() == FlowDecision::FINISHED_DUPLICATE_EXCEEDED);
+    }
 
     return 0;
 }

--- a/tests/unit/flow/test_flow_thresholds.cpp
+++ b/tests/unit/flow/test_flow_thresholds.cpp
@@ -1,47 +1,63 @@
 // SPDX-License-Identifier: BSD-2-Clause
+//
+// Pins down: FlowEngine threshold inputs (duplicate ratio,
+// reordering ratio) are wired through to evaluate_if_ready() without
+// crashing or producing an invalid decision enum.
+//
+// Note: today this is a smoke test — it asserts that the engine's
+// final_decision() is one of the legal enum values rather than the
+// specific verdict each scenario should produce. If you tighten the
+// engine's behaviour for these cases, replace the wide `assert(any of ...)`
+// with the exact expected `FlowDecision`.
+//
+// If this fails: the threshold knobs are not being read into the
+// engine, or evaluate_if_ready() returns a garbage enum value.
+
+#include "test_helpers.h"
 
 #include "openpenny/config/Config.h"
 #include "openpenny/penny/flow/engine/FlowEngine.h"
 
 #include <cassert>
-#include <chrono>
 
-using namespace std::chrono;
+using openpenny::test::Section;
+using FlowDecision = openpenny::penny::FlowEngine::FlowDecision;
+
+// Accept any legal enum value. Used while the test is a smoke test;
+// replace at call sites with the exact expected decision when the
+// engine's semantics for that scenario are finalised.
+static bool is_legal_decision(FlowDecision d) {
+    return d == FlowDecision::PENDING
+        || d == FlowDecision::FINISHED_CLOSED_LOOP
+        || d == FlowDecision::FINISHED_NOT_CLOSED_LOOP
+        || d == FlowDecision::FINISHED_DUPLICATE_EXCEEDED
+        || d == FlowDecision::FINISHED_NO_DECISION;
+}
 
 int main() {
     openpenny::Config cfg;
-    cfg.active.max_duplicate_fraction = 0.15;      // 15%
-    cfg.active.max_out_of_order_fraction = 0.8; // 80%
+    cfg.active.max_duplicate_fraction    = 0.15; // 15%
+    cfg.active.max_out_of_order_fraction = 0.80; // 80%
 
-    // Duplicate ratio check: 2 duplicates / 10 data = 0.2 > 0.15 -> RecommendPass.
     {
+        Section _{"duplicate ratio over threshold (2 dups / 10 data = 0.20 > 0.15)"};
+
         openpenny::penny::FlowEngine flow(cfg.active);
         for (int i = 0; i < 10; ++i) flow.record_data_packet();
-        for (int i = 0; i < 2; ++i) flow.record_duplicate_packet();
+        for (int i = 0; i < 2;  ++i) flow.record_duplicate_packet();
 
         flow.evaluate_if_ready();
-        auto decision = flow.final_decision();
-        assert(decision == openpenny::penny::FlowEngine::FlowDecision::FINISHED_NO_DECISION ||
-               decision == openpenny::penny::FlowEngine::FlowDecision::FINISHED_CLOSED_LOOP ||
-               decision == openpenny::penny::FlowEngine::FlowDecision::FINISHED_NOT_CLOSED_LOOP ||
-               decision == openpenny::penny::FlowEngine::FlowDecision::FINISHED_DUPLICATE_EXCEEDED ||
-               decision == openpenny::penny::FlowEngine::FlowDecision::PENDING);
+        assert(is_legal_decision(flow.final_decision()));
     }
 
-    // Out-of-order ratio check: 9/10 out-of-order -> 0.9 > 0.8 -> RecommendPass.
     {
+        Section _{"reordering ratio over threshold (9 ooo / 10 = 0.90 > 0.80)"};
+
         openpenny::penny::FlowEngine flow(cfg.active);
-        // First packet in order.
-        flow.track_ordering(1000);
-        // Subsequent packets out of order.
-        for (int i = 0; i < 9; ++i) flow.track_ordering(900 - i);
+        flow.track_ordering(1000);                  // first in-order
+        for (int i = 0; i < 9; ++i) flow.track_ordering(900 - i); // rest out-of-order
         flow.evaluate_if_ready();
-        auto decision = flow.final_decision();
-        assert(decision == openpenny::penny::FlowEngine::FlowDecision::FINISHED_NO_DECISION ||
-               decision == openpenny::penny::FlowEngine::FlowDecision::FINISHED_CLOSED_LOOP ||
-               decision == openpenny::penny::FlowEngine::FlowDecision::FINISHED_NOT_CLOSED_LOOP ||
-               decision == openpenny::penny::FlowEngine::FlowDecision::FINISHED_DUPLICATE_EXCEEDED ||
-               decision == openpenny::penny::FlowEngine::FlowDecision::PENDING);
+        assert(is_legal_decision(flow.final_decision()));
     }
 
     return 0;

--- a/tests/unit/flow/test_gap_management.cpp
+++ b/tests/unit/flow/test_gap_management.cpp
@@ -1,4 +1,18 @@
 // SPDX-License-Identifier: BSD-2-Clause
+//
+// Pins down: FlowEngine::fill_gaps() reports a gap as filled only when
+// the retransmissions cover the entire registered range.
+//
+// Scenario: register one gap for [1000, 1100). The first retransmit
+// covers [1000, 1050) (half). fill_gaps() must return an empty list
+// then. The second retransmit covers [1050, 1100). Now fill_gaps()
+// must return the original gap's packet_id.
+//
+// If this fails: partial retransmissions either get silently absorbed
+// (false positive — flow looks closed-loop too early) or never close
+// out (false negative — flow stays pending forever).
+
+#include "test_helpers.h"
 
 #include "openpenny/config/Config.h"
 #include "openpenny/penny/flow/manager/ThreadFlowManager.h"
@@ -6,48 +20,59 @@
 
 #include <cassert>
 #include <chrono>
-using namespace std::chrono;
-using openpenny::penny::FlowTrackingState;
-namespace net = openpenny::net;
 
-static openpenny::penny::FlowEngineEntry& track(openpenny::penny::ThreadFlowManager& table,
-                                               const openpenny::FlowKey& key,
-                                               bool syn,
-                                               uint32_t seq,
-                                               steady_clock::time_point ts) {
-    net::PacketView pkt{};
-    pkt.flow = key;
-    pkt.tcp.seq = seq;
-    pkt.tcp.flags = syn ? 0x02 : 0x00;
-    pkt.payload_bytes = syn ? 0 : 100;
+using namespace std::chrono;
+using openpenny::test::Section;
+using openpenny::test::kTcpSyn;
+using openpenny::test::make_packet;
+
+namespace {
+
+// Push one packet through the manager and return the resulting entry.
+openpenny::penny::FlowEngineEntry& track(openpenny::penny::ThreadFlowManager& table,
+                                         const openpenny::FlowKey& key,
+                                         bool                       syn,
+                                         std::uint32_t              seq,
+                                         steady_clock::time_point   ts) {
+    const auto pkt = make_packet(key,
+                                 seq,
+                                 /*payload=*/syn ? 0 : 100,
+                                 /*flags=*/  syn ? kTcpSyn : 0);
     table.track_packet(pkt, ts);
     return *table.find(key);
 }
+
+} // namespace
 
 int main() {
     openpenny::Config cfg;
     cfg.active.rtt_timeout_factor = 3.0;
 
     openpenny::penny::ThreadFlowManager table(cfg.active);
-    openpenny::FlowKey flow{10, 20, 1111, 2222, 6};
-    auto now = steady_clock::time_point{};
-
-    // Register a gap representing a dropped packet.
-    auto& entry = track(table, flow, true, 1000, now);
+    const openpenny::FlowKey flow{10, 20, 1111, 2222, /*ip_proto=*/6};
+    const auto now    = steady_clock::time_point{};
     const auto gap_id = openpenny::penny::make_packet_drop_id(1000, 100);
-    entry.flow.register_gap(1000, 1100, gap_id);
 
-    // First retransmission partially fills the gap.
-    auto partial_time = now + milliseconds(100);
-    auto& entry_after_partial = track(table, flow, false, 1000, partial_time);
-    auto filled_partial = entry_after_partial.flow.fill_gaps(1000, 1050);
-    assert(filled_partial.empty()); // partial repair should not be reported yet.
+    {
+        Section _{"register a gap for [1000, 1100)"};
+        auto& entry = track(table, flow, /*syn=*/true, 1000, now);
+        entry.flow.register_gap(1000, 1100, gap_id);
+    }
 
-    // Another retransmission completes the gap.
-    auto final_time = now + milliseconds(200);
-    auto& entry_after_final = track(table, flow, false, 1050, final_time);
-    auto filled_final = entry_after_final.flow.fill_gaps(1050, 1100);
-    assert(filled_final.size() == 1 && filled_final.front() == gap_id);
+    {
+        Section _{"partial retransmit [1000, 1050) does not close the gap"};
+        auto& entry = track(table, flow, /*syn=*/false, 1000, now + milliseconds(100));
+        const auto filled = entry.flow.fill_gaps(1000, 1050);
+        assert(filled.empty());
+    }
+
+    {
+        Section _{"second retransmit completes the range and reports gap closed"};
+        auto& entry = track(table, flow, /*syn=*/false, 1050, now + milliseconds(200));
+        const auto filled = entry.flow.fill_gaps(1050, 1100);
+        assert(filled.size() == 1);
+        assert(filled.front() == gap_id);
+    }
 
     return 0;
 }

--- a/tests/unit/flow/test_helpers.h
+++ b/tests/unit/flow/test_helpers.h
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: BSD-2-Clause
+//
+// Shared helpers for the tests under tests/unit/flow/.
+//
+// Goals:
+// - Replace magic numbers (TCP flag bits, default 5-tuple values) with
+//   named constants so a reader can tell intent at a glance.
+// - Cut PacketView construction boilerplate to a single call.
+// - Print a one-line banner per scenario so test output narrates itself
+//   when a test fails or when running under `ctest --verbose`.
+//
+// All helpers are header-only and dependency-free beyond what the tests
+// already include.
+
+#pragma once
+
+#include "openpenny/net/Packet.h"
+#include "openpenny/penny/flow/timer/ThreadFlowEventTimer.h"
+
+#include <chrono>
+#include <cstdint>
+#include <iostream>
+#include <string>
+#include <thread>
+
+namespace openpenny::test {
+
+// --- TCP flag bits ---------------------------------------------------------
+inline constexpr std::uint8_t kTcpFin = 0x01;
+inline constexpr std::uint8_t kTcpSyn = 0x02;
+inline constexpr std::uint8_t kTcpRst = 0x04;
+inline constexpr std::uint8_t kTcpPsh = 0x08;
+inline constexpr std::uint8_t kTcpAck = 0x10;
+
+// --- Default flow tuple ----------------------------------------------------
+// A throwaway 5-tuple used by tests that only care about flow lifecycle,
+// not packet routing. Override individual fields when a test pins down
+// per-tuple behaviour.
+inline FlowKey make_flow_key(std::uint32_t src_ip = 1,
+                             std::uint32_t dst_ip = 2,
+                             std::uint16_t src_port = 1000,
+                             std::uint16_t dst_port = 2000,
+                             std::uint8_t  ip_proto = 6 /* TCP */) {
+    return FlowKey{src_ip, dst_ip, src_port, dst_port, ip_proto};
+}
+
+// --- PacketView construction ----------------------------------------------
+// One-line builder. Defaults match a plain data packet of length 1.
+// Pass flags = kTcpSyn (etc.) for handshakes; payload = 0 for pure ACKs.
+inline net::PacketView make_packet(const FlowKey& flow,
+                                   std::uint32_t  seq,
+                                   std::uint64_t  payload = 1,
+                                   std::uint8_t   flags   = 0) {
+    net::PacketView pkt{};
+    pkt.flow          = flow;
+    pkt.tcp.seq       = seq;
+    pkt.tcp.flags     = flags;
+    pkt.payload_bytes = payload;
+    return pkt;
+}
+
+// --- Scenario banner -------------------------------------------------------
+// RAII helper. Constructing it prints "[test] scenario: <name>" so a
+// failing assertion can be located by reading the test log; the
+// destructor prints "[test]   ok: <name>" only when the scope exited
+// without an unhandled exception (i.e. no assert tripped).
+class Section {
+public:
+    explicit Section(std::string name)
+        : name_(std::move(name)),
+          uncaught_(std::uncaught_exceptions()) {
+        std::cout << "scenario: " << name_ << '\n';
+    }
+    ~Section() {
+        if (std::uncaught_exceptions() == uncaught_) {
+            std::cout << "    ok:   " << name_ << '\n';
+        }
+    }
+    Section(const Section&)            = delete;
+    Section& operator=(const Section&) = delete;
+
+private:
+    std::string name_;
+    int         uncaught_;
+};
+
+// --- Timer-singleton reset -------------------------------------------------
+// The drop-timer singleton is shared across tests when the test binary
+// runs multiple scenarios in one process. Call this at scenario
+// boundaries (and at the start of main()) to avoid cross-pollution.
+inline void reset_drop_timer() {
+    penny::ThreadFlowEventTimerManager::instance().stop();
+}
+
+// --- Sleep helper ----------------------------------------------------------
+inline void sleep_ms(int ms) {
+    std::this_thread::sleep_for(std::chrono::milliseconds(ms));
+}
+
+} // namespace openpenny::test

--- a/tests/unit/flow/test_initial_flow_monitoring.cpp
+++ b/tests/unit/flow/test_initial_flow_monitoring.cpp
@@ -1,126 +1,117 @@
 // SPDX-License-Identifier: BSD-2-Clause
+//
+// Pins down: ThreadFlowManager admits new flows into the correct
+// FlowTrackingState depending on the packets seen so far.
+//
+//   - SYN first             -> ACTIVE_SEEN_SYN
+//   - Data first, < grace   -> PENDING_SEEN_DATA
+//   - Data first, > grace   -> ACTIVE_SEEN_DATA (promotion on timeout)
+//   - Data first then SYN   -> ACTIVE_SEEN_SYN (promotion on SYN arrival)
+//
+// Each transition also updates the engine's highest_sequence().
+//
+// If this fails: data-first flows never promote (or promote too soon),
+// breaking the closed-loop / open-loop classification for sessions
+// whose SYN was missed.
+
+#include "test_helpers.h"
 
 #include "openpenny/config/Config.h"
-#include "openpenny/penny/flow/manager/ThreadFlowManager.h"
 #include "openpenny/net/Packet.h"
+#include "openpenny/penny/flow/manager/ThreadFlowManager.h"
 
 #include <cassert>
 #include <chrono>
 
 using namespace std::chrono;
 using openpenny::penny::FlowTrackingState;
-using openpenny::net::PacketView;
-namespace net = openpenny::net;
+using openpenny::test::Section;
+using openpenny::test::kTcpSyn;
+using openpenny::test::make_packet;
 
-    static void assert_state(FlowTrackingState actual, FlowTrackingState expected) {
-        assert(actual == expected && "Unexpected flow monitor state");
+namespace {
+
+void assert_state(FlowTrackingState actual, FlowTrackingState expected) {
+    assert(actual == expected && "Unexpected flow monitor state");
+}
+
+} // namespace
+
+int main() {
+    openpenny::Config cfg;
+    cfg.active.rtt_timeout_factor = 3.0; // 3s grace before data-first promotion
+
+    openpenny::penny::ThreadFlowManager table(cfg.active);
+
+    {
+        Section _{"SYN-first flow -> ACTIVE_SEEN_SYN"};
+        const openpenny::FlowKey flow{1, 2, 1000, 2000, /*ip_proto=*/6};
+        const auto now = steady_clock::time_point{};
+
+        table.track_packet(make_packet(flow, /*seq=*/100, /*payload=*/0, kTcpSyn), now);
+        auto& entry = *table.find(flow);
+        assert_state(entry.state, FlowTrackingState::ACTIVE_SEEN_SYN);
+        assert(entry.flow.highest_sequence() == 100);
+
+        // A later data packet keeps the state and advances the seq.
+        table.track_packet(make_packet(flow, /*seq=*/150), now + milliseconds(500));
+        auto& entry2 = *table.find(flow);
+        assert(entry2.flow.highest_sequence() == 150);
     }
 
-    int main() {
-        openpenny::Config cfg;
-        cfg.active.rtt_timeout_factor = 3.0;
+    {
+        Section _{"data-first flow within grace -> PENDING_SEEN_DATA"};
+        const openpenny::FlowKey flow{3, 4, 3000, 4000, /*ip_proto=*/6};
+        const auto t0 = steady_clock::time_point{};
 
-        openpenny::penny::ThreadFlowManager table(cfg.active);
-    auto now = steady_clock::time_point{};
+        table.track_packet(make_packet(flow, 50,  /*payload=*/10), t0);
+        auto& entry = *table.find(flow);
+        assert_state(entry.state, FlowTrackingState::PENDING_SEEN_DATA);
+        assert(entry.flow.highest_sequence() == 50);
 
-    // Case 1: Flow starts with SYN.
-    openpenny::FlowKey flow_syn{1, 2, 1000, 2000, 6};
-    net::PacketView syn_pkt{};
-    syn_pkt.flow = flow_syn;
-    syn_pkt.tcp.seq = 100;
-    syn_pkt.tcp.flags = 0x02; // SYN
-    syn_pkt.payload_bytes = 0;
-    table.track_packet(syn_pkt, now);
-    auto* syn_entry_ptr = table.find(flow_syn);
-    auto& syn_entry = *syn_entry_ptr;
-    assert_state(syn_entry.state, FlowTrackingState::ACTIVE_SEEN_SYN);
-    assert(syn_entry.flow.highest_sequence() == 100);
+        table.track_packet(make_packet(flow, 60,  /*payload=*/10), t0 + milliseconds(500));
+        auto& entry2 = *table.find(flow);
+        assert_state(entry2.state, FlowTrackingState::PENDING_SEEN_DATA);
+        assert(entry2.flow.highest_sequence() == 60);
+    }
 
-    // Subsequent data packet after SYN should remain active and update highest seq.
-    auto later = now + milliseconds(500);
-    net::PacketView syn_data_pkt{};
-    syn_data_pkt.flow = flow_syn;
-    syn_data_pkt.tcp.seq = 150;
-    syn_data_pkt.payload_bytes = 1;
-    table.track_packet(syn_data_pkt, later);
-    auto* syn_entry_data_ptr = table.find(flow_syn);
-    auto& syn_entry_data = *syn_entry_data_ptr;
+    {
+        Section _{"data-first flow promotes to ACTIVE_SEEN_DATA after grace period"};
+        const openpenny::FlowKey flow{3, 4, 3000, 4000, /*ip_proto=*/6};
+        const auto t0 = steady_clock::time_point{};
 
-    // Case 2: Flow starts with data (no SYN yet).
-    openpenny::FlowKey flow_data{3, 4, 3000, 4000, 6};
-    auto t0 = steady_clock::time_point{};
-    net::PacketView data_pkt0{};
-    data_pkt0.flow = flow_data;
-    data_pkt0.tcp.seq = 50;
-    data_pkt0.payload_bytes = 10;
-    table.track_packet(data_pkt0, t0);
-    auto& data_entry = *table.find(flow_data);
-    assert_state(data_entry.state, FlowTrackingState::PENDING_SEEN_DATA);
-    assert(data_entry.flow.highest_sequence() == 50);
+        table.track_packet(make_packet(flow, 40, /*payload=*/10), t0 + milliseconds(3500));
+        auto& entry = *table.find(flow);
+        assert_state(entry.state, FlowTrackingState::ACTIVE_SEEN_DATA);
+        assert(entry.flow.highest_sequence() == 60); // unchanged: 40 < 60
+    }
 
-    // Another data packet before timeout should remain in PENDING_SEEN_DATA.
-    auto t1 = t0 + milliseconds(500);
-    net::PacketView data_pkt1{};
-    data_pkt1.flow = flow_data;
-    data_pkt1.tcp.seq = 60;
-    data_pkt1.payload_bytes = 10;
-    table.track_packet(data_pkt1, t1);
-    auto& data_entry2 = *table.find(flow_data);
-    assert_state(data_entry2.state, FlowTrackingState::PENDING_SEEN_DATA);
-    assert(data_entry2.flow.highest_sequence() == 60);
+    {
+        Section _{"data-first followed by SYN promotes to ACTIVE_SEEN_SYN"};
+        const openpenny::FlowKey flow{5, 6, 1234, 4321, /*ip_proto=*/6};
+        const auto t0 = steady_clock::time_point{};
 
-    // After rtt_timeout_factor elapses without SYN, flow should promote to ACTIVE_SEEN_DATA.
-    auto t2 = t0 + milliseconds(3500);
-    net::PacketView data_pkt2{};
-    data_pkt2.flow = flow_data;
-    data_pkt2.tcp.seq = 40;
-    data_pkt2.payload_bytes = 10;
-    table.track_packet(data_pkt2, t2);
-    auto& data_entry3 = *table.find(flow_data);
-    assert_state(data_entry3.state, FlowTrackingState::ACTIVE_SEEN_DATA);
-    assert(data_entry3.flow.highest_sequence() == 60);
+        table.track_packet(make_packet(flow, 5, /*payload=*/5), t0);
+        table.track_packet(make_packet(flow, 6, /*payload=*/5), t0 + milliseconds(200));
+        assert_state(table.find(flow)->state, FlowTrackingState::PENDING_SEEN_DATA);
 
-    // Case 3: Flow receives SYN after data-first start.
-    openpenny::FlowKey flow_data_then_syn{5, 6, 1234, 4321, 6};
-    auto td0 = steady_clock::time_point{};
-    net::PacketView first_data_pkt{};
-    first_data_pkt.flow = flow_data_then_syn;
-    first_data_pkt.tcp.seq = 5;
-    first_data_pkt.payload_bytes = 5;
-    table.track_packet(first_data_pkt, td0);
-    auto& first_data = *table.find(flow_data_then_syn);
-    assert_state(first_data.state, FlowTrackingState::PENDING_SEEN_DATA);
+        table.track_packet(make_packet(flow, /*seq=*/1000, /*payload=*/0, kTcpSyn),
+                           t0 + milliseconds(500));
+        auto& entry = *table.find(flow);
+        assert_state(entry.state, FlowTrackingState::ACTIVE_SEEN_SYN);
+        assert(entry.flow.highest_sequence() == 1000);
+    }
 
-    auto td1 = td0 + milliseconds(200);
-    net::PacketView second_data_pkt{};
-    second_data_pkt.flow = flow_data_then_syn;
-    second_data_pkt.tcp.seq = 6;
-    second_data_pkt.payload_bytes = 5;
-    table.track_packet(second_data_pkt, td1);
-    auto& second_data = *table.find(flow_data_then_syn);
-    assert_state(second_data.state, FlowTrackingState::PENDING_SEEN_DATA);
+    {
+        Section _{"post-promotion data updates seq and stays ACTIVE_SEEN_DATA"};
+        const openpenny::FlowKey flow{5, 6, 1234, 4321, /*ip_proto=*/6};
+        const auto t = steady_clock::time_point{} + milliseconds(550);
 
-    auto td2 = td0 + milliseconds(500);
-    net::PacketView syn_after_pkt{};
-    syn_after_pkt.flow = flow_data_then_syn;
-    syn_after_pkt.tcp.seq = 1000;
-    syn_after_pkt.tcp.flags = 0x02;
-    syn_after_pkt.payload_bytes = 0;
-    table.track_packet(syn_after_pkt, td2);
-    auto& syn_after_data = *table.find(flow_data_then_syn);
-    assert_state(syn_after_data.state, FlowTrackingState::ACTIVE_SEEN_SYN);
-    assert(syn_after_data.flow.highest_sequence() == 1000);
-
-    // Case 4: Duplicate detection (no state change but sequence update).
-    auto td3 = td2 + milliseconds(50);
-    net::PacketView data_after_syn_pkt{};
-    data_after_syn_pkt.flow = flow_data_then_syn;
-    data_after_syn_pkt.tcp.seq = 1500;
-    data_after_syn_pkt.payload_bytes = 10;
-    table.track_packet(data_after_syn_pkt, td3);
-    auto& data_after_syn = *table.find(flow_data_then_syn);
-    assert_state(data_after_syn.state, FlowTrackingState::ACTIVE_SEEN_DATA);
-    assert(data_after_syn.flow.highest_sequence() == 1500);
+        table.track_packet(make_packet(flow, /*seq=*/1500, /*payload=*/10), t);
+        auto& entry = *table.find(flow);
+        assert_state(entry.state, FlowTrackingState::ACTIVE_SEEN_DATA);
+        assert(entry.flow.highest_sequence() == 1500);
+    }
 
     return 0;
 }

--- a/tests/unit/flow/test_sequence_ordering.cpp
+++ b/tests/unit/flow/test_sequence_ordering.cpp
@@ -1,35 +1,56 @@
 // SPDX-License-Identifier: BSD-2-Clause
+//
+// Pins down: FlowEngine::track_ordering() correctly classifies each
+// observed sequence number as in-order or out-of-order against the
+// running highest-seen sequence.
+//
+// If this fails: per-flow in-order / out-of-order counters drift and
+// the duplicate / reordering thresholds compute the wrong fractions.
+
+#include "test_helpers.h"
 
 #include "openpenny/config/Config.h"
 #include "openpenny/penny/flow/engine/FlowEngine.h"
 
 #include <cassert>
-#include <chrono>
 
-using namespace std::chrono;
+using openpenny::test::Section;
 
 int main() {
     openpenny::Config cfg;
     openpenny::penny::FlowEngine flow(cfg.active);
 
-    flow.record_syn(1000);
-    bool first = flow.track_ordering(1000);
-    assert(first);
-    assert(flow.in_order_packets() == 1);
-    assert(flow.out_of_order_packets() == 0);
+    {
+        Section _{"first SYN seq starts the in-order series"};
+        flow.record_syn(1000);
+        const bool first = flow.track_ordering(1000);
+        assert(first);
+        assert(flow.in_order_packets() == 1);
+        assert(flow.out_of_order_packets() == 0);
+    }
 
-    bool second = flow.track_ordering(1050);
-    assert(second);
-    assert(flow.in_order_packets() == 2);
-    assert(flow.highest_sequence() == 1050);
+    {
+        Section _{"strictly increasing seq stays in order"};
+        const bool second = flow.track_ordering(1050);
+        assert(second);
+        assert(flow.in_order_packets() == 2);
+        assert(flow.highest_sequence() == 1050);
+    }
 
-    bool out_of_order = flow.track_ordering(1000);
-    assert(!out_of_order);
-    assert(flow.out_of_order_packets() == 1);
+    {
+        Section _{"seq below highest counts as out-of-order"};
+        const bool out_of_order = flow.track_ordering(1000);
+        assert(!out_of_order);
+        assert(flow.out_of_order_packets() == 1);
+    }
 
-    bool in_order_again = flow.track_ordering(1100);
-    assert(in_order_again);
-    assert(flow.in_order_packets() == 3);
+    {
+        Section _{"a later in-order seq does not reset out-of-order count"};
+        const bool in_order_again = flow.track_ordering(1100);
+        assert(in_order_again);
+        assert(flow.in_order_packets() == 3);
+        assert(flow.out_of_order_packets() == 1);
+    }
 
     return 0;
 }

--- a/tests/unit/flow/test_terminal_snapshot_resolution.cpp
+++ b/tests/unit/flow/test_terminal_snapshot_resolution.cpp
@@ -1,58 +1,62 @@
 // SPDX-License-Identifier: BSD-2-Clause
+//
+// Pins down: FlowEngine::resolve_pending_snapshots() classifies an
+// outstanding drop snapshot correctly depending on when teardown
+// arrives relative to the retransmission timeout:
+//   - teardown BEFORE the deadline -> Invalid (not enough evidence)
+//   - explicit mark_snapshot_expired (FIN/RST semantics) -> Expired
+//   - teardown AFTER the deadline   -> Expired
+//
+// If this fails: closed-loop / not-closed-loop classification for
+// flows that end while drops are still outstanding goes wrong.
+
+#include "test_helpers.h"
 
 #include "openpenny/config/Config.h"
 #include "openpenny/app/core/PerThreadStats.h"
 #include "openpenny/penny/flow/engine/FlowEngine.h"
-#include "openpenny/penny/flow/timer/ThreadFlowEventTimer.h"
 
 #include <cassert>
 #include <chrono>
-#include <cstdint>
 #include <vector>
 
-namespace {
-
-openpenny::FlowKey make_flow_key(std::uint16_t sport) {
-    openpenny::FlowKey key{};
-    key.src = 0x0a000001;
-    key.dst = 0x0a000002;
-    key.sport = sport;
-    key.dport = 5201;
-    key.ip_proto = 6;
-    return key;
-}
-
-} // namespace
+using openpenny::test::Section;
+using openpenny::test::make_flow_key;
+using openpenny::test::reset_drop_timer;
 
 int main() {
     using Clock = std::chrono::steady_clock;
 
-    openpenny::penny::ThreadFlowEventTimerManager::instance().stop();
+    reset_drop_timer();
     openpenny::app::init_thread_counters(1);
     openpenny::app::set_thread_counter_index(0);
 
     openpenny::Config cfg;
-    cfg.active.drop_probability = 1.0;
-    cfg.active.rtt_timeout_factor = 60.0;
+    cfg.active.drop_probability   = 1.0;     // every droppable packet is dropped
+    cfg.active.rtt_timeout_factor = 60.0;    // generous deadline for the early-teardown case
 
     {
+        Section _{"teardown before timeout marks snapshot Invalid"};
+
         openpenny::penny::FlowEngine flow(cfg.active);
-        std::vector<openpenny::penny::SnapshotState> observed_states;
-        flow.set_flow_key(make_flow_key(1111));
-        flow.set_drop_sink([&observed_states](const openpenny::FlowKey&,
-                                              openpenny::penny::PacketDropId,
-                                              const openpenny::penny::PacketDropSnapshot& snapshot) {
-            observed_states.push_back(snapshot.state);
-        });
+        const auto key       = make_flow_key(0x0a000001, 0x0a000002, 1111, 5201);
         const auto drop_time = Clock::now();
-        const auto key = make_flow_key(1111);
         const auto packet_id = openpenny::penny::make_packet_drop_id(1000, 100);
+
+        std::vector<openpenny::penny::SnapshotState> observed;
+        flow.set_flow_key(key);
+        flow.set_drop_sink([&observed](const openpenny::FlowKey&,
+                                       openpenny::penny::PacketDropId,
+                                       const openpenny::penny::PacketDropSnapshot& s) {
+            observed.push_back(s.state);
+        });
 
         flow.record_data(1000, drop_time);
         assert(flow.drop_packet(1000, 1100, packet_id, key, drop_time));
         assert(openpenny::app::aggregate_counters().pending_retransmissions == 1);
 
-        // Generic teardown before the timeout should NOT mark the drop expired.
+        // Resolve well before the 60s timeout. The snapshot must NOT be
+        // promoted to Expired; insufficient evidence -> Invalid.
         flow.resolve_pending_snapshots(drop_time + std::chrono::seconds(1));
 
         assert(flow.pending_retransmissions() == 0);
@@ -61,22 +65,23 @@ int main() {
         assert(flow.drop_snapshots().size() == 1);
         assert(flow.drop_snapshots().front().second.state ==
                openpenny::penny::SnapshotState::Invalid);
-        assert(observed_states.size() == 2);
-        assert(observed_states.front() == openpenny::penny::SnapshotState::Pending);
-        assert(observed_states.back() == openpenny::penny::SnapshotState::Invalid);
+        assert(observed.size() == 2);
+        assert(observed.front() == openpenny::penny::SnapshotState::Pending);
+        assert(observed.back()  == openpenny::penny::SnapshotState::Invalid);
     }
 
     {
+        Section _{"FIN/RST path: mark_snapshot_expired promotes to Expired"};
+
         openpenny::penny::FlowEngine flow(cfg.active);
-        flow.set_flow_key(make_flow_key(1112));
+        const auto key       = make_flow_key(0x0a000001, 0x0a000002, 1112, 5201);
         const auto drop_time = Clock::now();
-        const auto key = make_flow_key(1112);
         const auto packet_id = openpenny::penny::make_packet_drop_id(1500, 100);
 
+        flow.set_flow_key(key);
         flow.record_data(1500, drop_time);
         assert(flow.drop_packet(1500, 1600, packet_id, key, drop_time));
 
-        // FIN semantics are immediate: outstanding drops become non-retransmitted.
         flow.mark_snapshot_expired(packet_id);
 
         assert(flow.pending_retransmissions() == 0);
@@ -87,23 +92,26 @@ int main() {
     }
 
     {
+        Section _{"teardown after timeout promotes snapshot to Expired"};
+
         openpenny::penny::FlowEngine flow(cfg.active);
-        std::vector<openpenny::penny::SnapshotState> observed_states;
-        flow.set_flow_key(make_flow_key(1113));
-        flow.set_drop_sink([&observed_states](const openpenny::FlowKey&,
-                                              openpenny::penny::PacketDropId,
-                                              const openpenny::penny::PacketDropSnapshot& snapshot) {
-            observed_states.push_back(snapshot.state);
-        });
+        const auto key       = make_flow_key(0x0a000001, 0x0a000002, 1113, 5201);
         const auto drop_time = Clock::now();
-        const auto key = make_flow_key(1113);
         const auto packet_id = openpenny::penny::make_packet_drop_id(2000, 100);
+
+        std::vector<openpenny::penny::SnapshotState> observed;
+        flow.set_flow_key(key);
+        flow.set_drop_sink([&observed](const openpenny::FlowKey&,
+                                       openpenny::penny::PacketDropId,
+                                       const openpenny::penny::PacketDropSnapshot& s) {
+            observed.push_back(s.state);
+        });
 
         flow.record_data(2000, drop_time);
         assert(flow.drop_packet(2000, 2100, packet_id, key, drop_time));
         assert(openpenny::app::aggregate_counters().pending_retransmissions == 1);
 
-        // Once the timeout has elapsed, teardown should promote to Expired.
+        // Resolve past the 60s timeout: snapshot must be Expired.
         flow.resolve_pending_snapshots(drop_time + std::chrono::seconds(61));
 
         assert(flow.pending_retransmissions() == 0);
@@ -112,11 +120,11 @@ int main() {
         assert(flow.drop_snapshots().size() == 1);
         assert(flow.drop_snapshots().front().second.state ==
                openpenny::penny::SnapshotState::Expired);
-        assert(observed_states.size() == 2);
-        assert(observed_states.front() == openpenny::penny::SnapshotState::Pending);
-        assert(observed_states.back() == openpenny::penny::SnapshotState::Expired);
+        assert(observed.size() == 2);
+        assert(observed.front() == openpenny::penny::SnapshotState::Pending);
+        assert(observed.back()  == openpenny::penny::SnapshotState::Expired);
     }
 
-    openpenny::penny::ThreadFlowEventTimerManager::instance().stop();
+    reset_drop_timer();
     return 0;
 }

--- a/tests/unit/net/test_packet_parser.cpp
+++ b/tests/unit/net/test_packet_parser.cpp
@@ -1,88 +1,118 @@
 // SPDX-License-Identifier: BSD-2-Clause
+//
+// Pins down: PacketParser::decode() extracts the TCP 5-tuple from
+// IPv4/TCP frames regardless of the VLAN tagging on the wire.
+//
+// Scenarios:
+//   - bare Ethernet (no VLAN tag)            -> EtherType 0x0800 (IPv4)
+//   - single VLAN tag (802.1Q, 0x8100)
+//   - single QinQ tag  (802.1ad, 0x88A8)
+//   - nested QinQ + VLAN tags
+//
+// If this fails: trunked traffic is silently mis-parsed; the flow
+// 5-tuple ends up wrong and the dataplane drops or mis-routes
+// matching packets.
 
 #include "openpenny/net/PacketParser.h"
 
 #include <array>
 #include <cassert>
 #include <cstdint>
+#include <iostream>
 #include <vector>
 
 namespace {
 
 void append_be16(std::vector<std::uint8_t>& frame, std::uint16_t value) {
     frame.push_back(static_cast<std::uint8_t>((value >> 8) & 0xff));
-    frame.push_back(static_cast<std::uint8_t>(value & 0xff));
+    frame.push_back(static_cast<std::uint8_t>( value       & 0xff));
 }
 
 void append_be32(std::vector<std::uint8_t>& frame, std::uint32_t value) {
     frame.push_back(static_cast<std::uint8_t>((value >> 24) & 0xff));
     frame.push_back(static_cast<std::uint8_t>((value >> 16) & 0xff));
-    frame.push_back(static_cast<std::uint8_t>((value >> 8) & 0xff));
-    frame.push_back(static_cast<std::uint8_t>(value & 0xff));
+    frame.push_back(static_cast<std::uint8_t>((value >>  8) & 0xff));
+    frame.push_back(static_cast<std::uint8_t>( value        & 0xff));
 }
 
+// Build a minimal IPv4 + TCP frame, optionally prefixed with N VLAN
+// tags. The last vlan_ethertypes entry must encode the outer EtherType
+// of the stacked tag header; subsequent tags chain via the embedded
+// "next EtherType" field until the IPv4 (0x0800) payload starts.
 std::vector<std::uint8_t> build_tcp_frame(const std::vector<std::uint16_t>& vlan_ethertypes) {
     std::vector<std::uint8_t> frame;
     frame.reserve(14 + vlan_ethertypes.size() * 4 + 20 + 20);
 
+    // Destination + source MAC.
     const std::array<std::uint8_t, 6> dst_mac{0x00, 0x11, 0x22, 0x33, 0x44, 0x55};
     const std::array<std::uint8_t, 6> src_mac{0x66, 0x77, 0x88, 0x99, 0xaa, 0xbb};
     frame.insert(frame.end(), dst_mac.begin(), dst_mac.end());
     frame.insert(frame.end(), src_mac.begin(), src_mac.end());
 
+    // EtherType + optional VLAN chain.
     if (vlan_ethertypes.empty()) {
-        append_be16(frame, 0x0800);
+        append_be16(frame, 0x0800); // IPv4
     } else {
         append_be16(frame, vlan_ethertypes.front());
         for (std::size_t i = 0; i < vlan_ethertypes.size(); ++i) {
-            append_be16(frame, static_cast<std::uint16_t>(0x0064 + i)); // TCI
-            append_be16(frame, i + 1 < vlan_ethertypes.size() ? vlan_ethertypes[i + 1] : 0x0800);
+            append_be16(frame, static_cast<std::uint16_t>(0x0064 + i));     // TCI: arbitrary VID
+            append_be16(frame,
+                        i + 1 < vlan_ethertypes.size() ? vlan_ethertypes[i + 1]
+                                                       : 0x0800);            // next or IPv4
         }
     }
 
-    // IPv4 header
-    frame.push_back(0x45); // version + IHL
-    frame.push_back(0x00); // DSCP/ECN
-    append_be16(frame, 40); // total length
-    append_be16(frame, 0x1234); // identification
-    append_be16(frame, 0x0000); // flags/fragment offset
-    frame.push_back(64); // TTL
-    frame.push_back(6);  // TCP
-    append_be16(frame, 0x0000); // header checksum
-    append_be32(frame, 0xc0a82903u); // 192.168.41.3
-    append_be32(frame, 0xc0a82902u); // 192.168.41.2
+    // IPv4 header.
+    frame.push_back(0x45);                 // version 4, IHL 5
+    frame.push_back(0x00);                 // DSCP / ECN
+    append_be16(frame, 40);                // total length (20 IP + 20 TCP)
+    append_be16(frame, 0x1234);            // identification
+    append_be16(frame, 0x0000);            // flags / fragment offset
+    frame.push_back(64);                   // TTL
+    frame.push_back(6);                    // protocol: TCP
+    append_be16(frame, 0x0000);            // header checksum
+    append_be32(frame, 0xc0a82903u);       // 192.168.41.3 (src)
+    append_be32(frame, 0xc0a82902u);       // 192.168.41.2 (dst)
 
-    // TCP header
-    append_be16(frame, 40000);
-    append_be16(frame, 5201);
-    append_be32(frame, 1);
-    append_be32(frame, 2);
-    frame.push_back(0x50); // data offset 5
-    frame.push_back(0x18); // PSH + ACK
-    append_be16(frame, 4096);
-    append_be16(frame, 0x0000); // checksum
-    append_be16(frame, 0x0000); // urgent pointer
+    // TCP header.
+    append_be16(frame, 40000);             // src port
+    append_be16(frame, 5201);              // dst port
+    append_be32(frame, 1);                 // seq
+    append_be32(frame, 2);                 // ack
+    frame.push_back(0x50);                 // data offset 5
+    frame.push_back(0x18);                 // flags: PSH+ACK
+    append_be16(frame, 4096);              // window
+    append_be16(frame, 0x0000);            // checksum
+    append_be16(frame, 0x0000);            // urgent pointer
 
     return frame;
 }
 
-void assert_decodes(const std::vector<std::uint8_t>& frame) {
-    openpenny::net::PacketView packet{};
-    assert(openpenny::net::PacketParser::decode(frame.data(), frame.size(), packet));
-    assert(packet.flow.src == 0xc0a82903u);
-    assert(packet.flow.dst == 0xc0a82902u);
-    assert(packet.flow.sport == 40000);
-    assert(packet.flow.dport == 5201);
-    assert(packet.flow.ip_proto == 6);
-    assert(packet.ip_proto == 6);
+void assert_decodes_to_5_tuple(const std::vector<std::uint8_t>& frame) {
+    openpenny::net::PacketView pkt{};
+    assert(openpenny::net::PacketParser::decode(frame.data(), frame.size(), pkt));
+    assert(pkt.flow.src      == 0xc0a82903u);
+    assert(pkt.flow.dst      == 0xc0a82902u);
+    assert(pkt.flow.sport    == 40000);
+    assert(pkt.flow.dport    == 5201);
+    assert(pkt.flow.ip_proto == 6);
+    assert(pkt.ip_proto      == 6);
 }
 
 } // namespace
 
 int main() {
-    assert_decodes(build_tcp_frame({}));
-    assert_decodes(build_tcp_frame({0x8100}));
-    assert_decodes(build_tcp_frame({0x88A8}));
-    assert_decodes(build_tcp_frame({0x88A8, 0x8100}));
+    std::cout << "scenario: bare Ethernet (no VLAN)\n";
+    assert_decodes_to_5_tuple(build_tcp_frame({}));
+
+    std::cout << "scenario: single 802.1Q VLAN tag\n";
+    assert_decodes_to_5_tuple(build_tcp_frame({0x8100}));
+
+    std::cout << "scenario: single 802.1ad QinQ tag\n";
+    assert_decodes_to_5_tuple(build_tcp_frame({0x88A8}));
+
+    std::cout << "scenario: nested QinQ + VLAN tags\n";
+    assert_decodes_to_5_tuple(build_tcp_frame({0x88A8, 0x8100}));
+
     return 0;
 }

--- a/tests/unit/net/test_traffic_match.cpp
+++ b/tests/unit/net/test_traffic_match.cpp
@@ -1,79 +1,129 @@
 // SPDX-License-Identifier: BSD-2-Clause
+//
+// Pins down: traffic_matches_flow() / traffic_matches_packet() respect
+// the per-rule fields they were given, and the default_action acts as
+// a catch-all when no rule matches.
+//
+// Each scenario rebuilds the rule set and checks both a matching and a
+// non-matching flow.
 
-#include "openpenny/net/TrafficMatch.h"
 #include "openpenny/net/Packet.h"
+#include "openpenny/net/TrafficMatch.h"
 
 #include <cassert>
+#include <iostream>
+
+namespace {
+
+openpenny::FlowKey make_match_target() {
+    openpenny::FlowKey k{};
+    k.src      = 0x0a010203u; // 10.1.2.3
+    k.dst      = 0xc0000201u; // 192.0.2.1
+    k.sport    = 12345;
+    k.dport    = 443;
+    k.ip_proto = 6; // TCP
+    return k;
+}
+
+} // namespace
 
 int main() {
-    openpenny::net::TrafficMatchConfig cfg{};
-    openpenny::net::TrafficMatchRule src_ip_rule{};
-    src_ip_rule.src_ip = openpenny::net::TrafficIpPrefix{0x0a010200u, 0xffffff00u};
-    src_ip_rule.label = "source-prefix";
-    cfg.rules.push_back(src_ip_rule);
+    using openpenny::net::TrafficIpPrefix;
+    using openpenny::net::TrafficMatchConfig;
+    using openpenny::net::TrafficMatchRule;
+    using openpenny::net::TrafficRuleAction;
+    using openpenny::net::traffic_matches_flow;
+    using openpenny::net::traffic_matches_packet;
 
-    openpenny::FlowKey matching{};
-    matching.src = 0x0a010203u;
-    matching.dst = 0xc0000201u;
-    matching.sport = 12345;
-    matching.dport = 443;
-    matching.ip_proto = 6;
+    const openpenny::FlowKey match = make_match_target();
+    TrafficMatchConfig cfg{};
 
-    openpenny::FlowKey non_matching = matching;
-    non_matching.src = 0x0a020203u;
+    {
+        std::cout << "scenario: src_ip /24 prefix match\n";
+        cfg.rules.clear();
+        TrafficMatchRule r{};
+        r.src_ip = TrafficIpPrefix{0x0a010200u, 0xffffff00u};
+        r.label  = "source-prefix";
+        cfg.rules.push_back(r);
 
-    assert(openpenny::net::traffic_matches_flow(cfg, matching));
-    assert(!openpenny::net::traffic_matches_flow(cfg, non_matching));
+        assert(traffic_matches_flow(cfg, match));
 
-    openpenny::net::TrafficMatchRule combined{};
-    combined.src_ip = openpenny::net::TrafficIpPrefix{0x0a010203u, 0xffffffffu};
-    combined.dst_ip = openpenny::net::TrafficIpPrefix{0xc0000200u, 0xffffff00u};
-    combined.src_port = 12345;
-    combined.dst_port = 443;
-    cfg.rules.clear();
-    cfg.rules.push_back(combined);
+        auto outside = match;
+        outside.src = 0x0a020203u;
+        assert(!traffic_matches_flow(cfg, outside));
+    }
 
-    assert(openpenny::net::traffic_matches_flow(cfg, matching));
+    {
+        std::cout << "scenario: combined 5-tuple match (src/dst/port/port)\n";
+        cfg.rules.clear();
+        TrafficMatchRule r{};
+        r.src_ip   = TrafficIpPrefix{0x0a010203u, 0xffffffffu};
+        r.dst_ip   = TrafficIpPrefix{0xc0000200u, 0xffffff00u};
+        r.src_port = 12345;
+        r.dst_port = 443;
+        cfg.rules.push_back(r);
 
-    auto wrong_dst = matching;
-    wrong_dst.dst = 0xc0000301u;
-    assert(!openpenny::net::traffic_matches_flow(cfg, wrong_dst));
+        assert(traffic_matches_flow(cfg, match));
 
-    auto wrong_src_port = matching;
-    wrong_src_port.sport = 50000;
-    assert(!openpenny::net::traffic_matches_flow(cfg, wrong_src_port));
+        auto wrong_dst = match;
+        wrong_dst.dst = 0xc0000301u;
+        assert(!traffic_matches_flow(cfg, wrong_dst));
 
-    openpenny::net::TrafficMatchRule dst_port_only{};
-    dst_port_only.dst_port = 443;
-    cfg.rules.clear();
-    cfg.rules.push_back(dst_port_only);
-    assert(openpenny::net::traffic_matches_flow(cfg, matching));
-    auto wrong_dst_port = matching;
-    wrong_dst_port.dport = 80;
-    assert(!openpenny::net::traffic_matches_flow(cfg, wrong_dst_port));
+        auto wrong_sport = match;
+        wrong_sport.sport = 50000;
+        assert(!traffic_matches_flow(cfg, wrong_sport));
+    }
 
-    openpenny::net::TrafficMatchRule tcp_https{};
-    tcp_https.ip_proto = 6;
-    tcp_https.dst_port = 443;
-    cfg.rules.clear();
-    cfg.rules.push_back(tcp_https);
+    {
+        std::cout << "scenario: dst_port-only rule\n";
+        cfg.rules.clear();
+        TrafficMatchRule r{};
+        r.dst_port = 443;
+        cfg.rules.push_back(r);
 
-    assert(openpenny::net::traffic_matches_flow(cfg, matching));
-    auto wrong_proto = matching;
-    wrong_proto.ip_proto = 17;
-    assert(!openpenny::net::traffic_matches_flow(cfg, wrong_proto));
+        assert(traffic_matches_flow(cfg, match));
 
-    openpenny::net::PacketView packet{};
-    packet.flow = matching;
-    packet.ip_proto = 6;
-    assert(openpenny::net::traffic_matches_packet(cfg, packet));
+        auto wrong_dport = match;
+        wrong_dport.dport = 80;
+        assert(!traffic_matches_flow(cfg, wrong_dport));
+    }
 
-    packet.ip_proto = 17;
-    packet.flow.ip_proto = 17;
-    assert(!openpenny::net::traffic_matches_packet(cfg, packet));
+    {
+        std::cout << "scenario: protocol + dst_port rule\n";
+        cfg.rules.clear();
+        TrafficMatchRule r{};
+        r.ip_proto = 6;
+        r.dst_port = 443;
+        cfg.rules.push_back(r);
 
-    cfg.default_action = openpenny::net::TrafficRuleAction::RedirectToUserspace;
-    assert(openpenny::net::traffic_matches_packet(cfg, packet));
+        assert(traffic_matches_flow(cfg, match));
+
+        auto wrong_proto = match;
+        wrong_proto.ip_proto = 17; // UDP
+        assert(!traffic_matches_flow(cfg, wrong_proto));
+    }
+
+    {
+        std::cout << "scenario: PacketView path agrees with flow path\n";
+        openpenny::net::PacketView pkt{};
+        pkt.flow     = match;
+        pkt.ip_proto = 6;
+        assert(traffic_matches_packet(cfg, pkt));
+
+        pkt.ip_proto      = 17; // UDP — current rule is TCP only
+        pkt.flow.ip_proto = 17;
+        assert(!traffic_matches_packet(cfg, pkt));
+    }
+
+    {
+        std::cout << "scenario: default_action = RedirectToUserspace acts as catch-all\n";
+        cfg.default_action = TrafficRuleAction::RedirectToUserspace;
+        openpenny::net::PacketView pkt{};
+        pkt.flow     = match;
+        pkt.ip_proto = 17;
+        pkt.flow.ip_proto = 17;
+        assert(traffic_matches_packet(cfg, pkt));
+    }
 
     return 0;
 }


### PR DESCRIPTION
## Summary

Cleaner unit tests. Every test now opens with a "Pins down / If this fails"
header and groups assertions into named scenarios. New
`tests/unit/flow/test_helpers.h` provides TCP-flag constants, a one-line
PacketView builder, and a scoped `Section` helper that prints scenario
names so `ctest -V` narrates itself. No assertion semantics changed.

## Testing

- [x] `cmake -S . -B build && cmake --build build`
- [x] Unit tests (`ctest --test-dir build`)
- [ ] Other (describe):

## Notes

- No behaviour or flag changes.